### PR TITLE
Stepify jobs

### DIFF
--- a/jobs/charts/release.yaml
+++ b/jobs/charts/release.yaml
@@ -1,52 +1,25 @@
 parameters:
-  serviceConnection: 'azurerm-nonprod'
-  aksResourceGroup: 'cnp-aks-rg'
-  aksCluster: 'cnp-aks-cluster'
-  acrName: 'hmcts'
-  chartName: ''
-  chartReleaseName: ''
-  chartNamespace: ''
+  serviceConnection: "azurerm-nonprod"
+  aksResourceGroup: "cnp-aks-rg"
+  aksCluster: "cnp-aks-cluster"
+  acrName: "hmcts"
+  chartName: ""
+  chartReleaseName: ""
+  chartNamespace: ""
+  helmVersion: "2.11.0"
 
 jobs:
-- job: ValidateChart
-  pool:
-    vmImage: 'Ubuntu 16.04'
-  steps:
-  - task: HelmInstaller@0
-    inputs:
-      helmVersion: '2.11.0'
-      installKubectl: false
-
-  - task: AzureCLI@1
-    displayName: 'AKS Authenticate'
-    inputs:
-      azureSubscription: ${{ parameters.serviceConnection }}
-      scriptLocation: 'inlineScript'
-      inlineScript: |
-        az aks get-credentials --resource-group ${{ parameters.aksResourceGroup }} --name ${{ parameters.aksCluster }}
-
-  - script: helm lint ${{ parameters.chartName }}
-    displayName: 'Helm Lint'
-
-  - script:  helm install ${{ parameters.chartName }} --name ${{ parameters.chartReleaseName }} --namespace ${{ parameters.chartNamespace }} -f ci-values.yaml --wait --timeout 120
-    displayName: 'Helm Install'
-
-  - script: helm test ${{ parameters.chartReleaseName }} --cleanup
-    displayName: 'Helm Test'
-
-  - script: helm package ${{ parameters.chartName }}
-    displayName: 'Helm Package'
-
-  - task: AzureCLI@1
-    displayName: 'Helm Publish'
-    inputs:
-      azureSubscription: ${{ parameters.serviceConnection }}
-      scriptLocation: 'inlineScript'
-      inlineScript: |
-        CHART_FILE=$(ls ${{ parameters.chartName }}-*)
-        az acr helm push --name ${{ parameters.acrName }} $CHART_FILE
-
-  - script: helm delete --purge ${{ parameters.chartReleaseName }}
-    continueOnError: true
-    condition: always()
-    displayName: 'Delete Test Chart'
+  - job: ValidateChart
+    pool:
+      vmImage: "Ubuntu 16.04"
+    steps:
+      - template: ../../steps/charts/release.yaml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
+          aksResourceGroup: ${{ parameters.aksResourceGroup }}
+          aksCluster: ${{ parameters.aksCluster }}
+          acrName: ${{ parameters.acrName }}
+          chartName: ${{ parameters.chartName }}
+          chartReleaseName: ${{ parameters.chartReleaseName }}
+          chartNamespace: ${{ parameters.chartNamespace }}
+          helmVersion: ${{ parameters.helmVersion }}

--- a/jobs/charts/validate.yaml
+++ b/jobs/charts/validate.yaml
@@ -12,7 +12,7 @@ jobs:
     pool:
       vmImage: "Ubuntu 16.04"
     steps:
-      - template: ../../steps/chart/validate.yaml
+      - template: ../../steps/charts/validate.yaml
         parameters:
           serviceConnection: ${{ parameters.serviceConnection }}
           aksResourceGroup: ${{ parameters.aksResourceGroup }}

--- a/jobs/charts/validate.yaml
+++ b/jobs/charts/validate.yaml
@@ -1,38 +1,21 @@
 parameters:
-  serviceConnection: 'azurerm-nonprod'
-  aksResourceGroup: 'cnp-aks-rg'
-  aksCluster: 'cnp-aks-cluster'
-  chartName: ''
-  chartReleaseName: ''
-  chartNamespace: ''
+  serviceConnection: "azurerm-nonprod"
+  aksResourceGroup: "cnp-aks-rg"
+  aksCluster: "cnp-aks-cluster"
+  chartName: ""
+  chartReleaseName: ""
+  chartNamespace: ""
 
 jobs:
-- job: ValidateChart
-  pool:
-    vmImage: 'Ubuntu 16.04'
-  steps:
-  - task: HelmInstaller@0
-    inputs:
-      helmVersion: '2.11.0'
-      installKubectl: false
-
-  - task: AzureCLI@1
-    displayName: 'AKS Authenticate'
-    inputs:
-      azureSubscription: ${{ parameters.serviceConnection }}
-      scriptLocation: 'inlineScript'
-      inlineScript: az aks get-credentials --resource-group ${{ parameters.aksResourceGroup }} --name ${{ parameters.aksCluster }}
-
-  - script: helm lint ${{ parameters.chartName }}
-    displayName: 'Helm Lint'
-
-  - script:  helm install ${{ parameters.chartName }} --name ${{ parameters.chartReleaseName }} --namespace ${{ parameters.chartNamespace }} -f ci-values.yaml --wait --timeout 120
-    displayName: 'Helm Install'
-
-  - script: helm test ${{ parameters.chartReleaseName }} --cleanup
-    displayName: 'Helm Test'
-
-  - script: helm delete --purge ${{ parameters.chartReleaseName }}
-    continueOnError: true
-    condition: always()
-    displayName: 'Delete Test Chart'
+  - job: ValidateChart
+    pool:
+      vmImage: "Ubuntu 16.04"
+    steps:
+      - template: ../../steps/chart-validate.yaml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
+          aksResourceGroup: ${{ parameters.aksResourceGroup }}
+          aksCluster: ${{ parameters.aksCluster }}
+          chartName: ${{ parameters.chartName }}
+          chartReleaseName: ${{ parameters.chartReleaseName }}
+          chartNamespace: ${{ parameters.chartNamespace }}

--- a/jobs/charts/validate.yaml
+++ b/jobs/charts/validate.yaml
@@ -5,13 +5,14 @@ parameters:
   chartName: ""
   chartReleaseName: ""
   chartNamespace: ""
+  helmVersion: "2.11.0"
 
 jobs:
   - job: ValidateChart
     pool:
       vmImage: "Ubuntu 16.04"
     steps:
-      - template: ../../steps/chart-validate.yaml
+      - template: ../../steps/chart/validate.yaml
         parameters:
           serviceConnection: ${{ parameters.serviceConnection }}
           aksResourceGroup: ${{ parameters.aksResourceGroup }}
@@ -19,3 +20,4 @@ jobs:
           chartName: ${{ parameters.chartName }}
           chartReleaseName: ${{ parameters.chartReleaseName }}
           chartNamespace: ${{ parameters.chartNamespace }}
+          helmVersion: ${{ parameters.helmVersion }}

--- a/steps/chart-validate.yaml
+++ b/steps/chart-validate.yaml
@@ -1,0 +1,34 @@
+parameters:
+  serviceConnection: "azurerm-nonprod"
+  aksResourceGroup: "cnp-aks-rg"
+  aksCluster: "cnp-aks-cluster"
+  chartName: ""
+  chartReleaseName: ""
+  chartNamespace: ""
+
+steps:
+  - task: HelmInstaller@0
+    inputs:
+      helmVersion: "2.11.0"
+      installKubectl: false
+
+  - task: AzureCLI@1
+    displayName: "AKS Authenticate"
+    inputs:
+      azureSubscription: ${{ parameters.serviceConnection }}
+      scriptLocation: "inlineScript"
+      inlineScript: az aks get-credentials --resource-group ${{ parameters.aksResourceGroup }} --name ${{ parameters.aksCluster }}
+
+  - script: helm lint ${{ parameters.chartName }}
+    displayName: "Helm Lint"
+
+  - script: helm install ${{ parameters.chartName }} --name ${{ parameters.chartReleaseName }} --namespace ${{ parameters.chartNamespace }} -f ci-values.yaml --wait --timeout 120
+    displayName: "Helm Install"
+
+  - script: helm test ${{ parameters.chartReleaseName }} --cleanup
+    displayName: "Helm Test"
+
+  - script: helm delete --purge ${{ parameters.chartReleaseName }}
+    continueOnError: true
+    condition: always()
+    displayName: "Delete Test Chart"

--- a/steps/charts/release.yaml
+++ b/steps/charts/release.yaml
@@ -1,0 +1,39 @@
+parameters:
+  serviceConnection: "azurerm-nonprod"
+  aksResourceGroup: "cnp-aks-rg"
+  aksCluster: "cnp-aks-cluster"
+  acrName: "hmcts"
+  chartName: ""
+  chartReleaseName: ""
+  chartNamespace: ""
+  helmVersion: "2.11.0"
+
+steps:
+  - task: HelmInstaller@0
+    inputs:
+      helmVersion: ${{ parameters.helmVersion }}
+      installKubectl: false
+
+  - task: AzureCLI@1
+    displayName: "AKS Authenticate"
+    inputs:
+      azureSubscription: ${{ parameters.serviceConnection }}
+      scriptLocation: "inlineScript"
+      inlineScript: az aks get-credentials --resource-group ${{ parameters.aksResourceGroup }} --name ${{ parameters.aksCluster }}
+
+  - script: helm package ${{ parameters.chartName }}
+    displayName: "Helm Package"
+
+  - task: AzureCLI@1
+    displayName: "Helm Publish"
+    inputs:
+      azureSubscription: ${{ parameters.serviceConnection }}
+      scriptLocation: "inlineScript"
+      inlineScript: |
+        CHART_FILE=$(ls ${{ parameters.chartName }}-*)
+        az acr helm push --name ${{ parameters.acrName }} $CHART_FILE
+
+  - script: helm delete --purge ${{ parameters.chartReleaseName }}
+    continueOnError: true
+    condition: always()
+    displayName: "Delete Test Chart"

--- a/steps/charts/release.yaml
+++ b/steps/charts/release.yaml
@@ -32,8 +32,3 @@ steps:
       inlineScript: |
         CHART_FILE=$(ls ${{ parameters.chartName }}-*)
         az acr helm push --name ${{ parameters.acrName }} $CHART_FILE
-
-  - script: helm delete --purge ${{ parameters.chartReleaseName }}
-    continueOnError: true
-    condition: always()
-    displayName: "Delete Test Chart"

--- a/steps/charts/validate.yaml
+++ b/steps/charts/validate.yaml
@@ -5,11 +5,12 @@ parameters:
   chartName: ""
   chartReleaseName: ""
   chartNamespace: ""
+  helmVersion: "2.11.0"
 
 steps:
   - task: HelmInstaller@0
     inputs:
-      helmVersion: "2.11.0"
+      helmVersion: ${{ parameters.helmVersion }}
       installKubectl: false
 
   - task: AzureCLI@1

--- a/steps/charts/validate.yaml
+++ b/steps/charts/validate.yaml
@@ -20,6 +20,9 @@ steps:
       scriptLocation: "inlineScript"
       inlineScript: az aks get-credentials --resource-group ${{ parameters.aksResourceGroup }} --name ${{ parameters.aksCluster }}
 
+  - script: helm delete --purge ${{ parameters.chartReleaseName }} || true
+    displayName: "Delete Previous Test Chart"
+
   - script: helm lint ${{ parameters.chartName }}
     displayName: "Helm Lint"
 
@@ -28,8 +31,3 @@ steps:
 
   - script: helm test ${{ parameters.chartReleaseName }} --cleanup
     displayName: "Helm Test"
-
-  - script: helm delete --purge ${{ parameters.chartReleaseName }}
-    continueOnError: true
-    condition: always()
-    displayName: "Delete Test Chart"

--- a/steps/charts/validate.yaml
+++ b/steps/charts/validate.yaml
@@ -31,3 +31,6 @@ steps:
 
   - script: helm test ${{ parameters.chartReleaseName }} --cleanup
     displayName: "Helm Test"
+
+  - script: helm delete --purge ${{ parameters.chartReleaseName }}
+    displayName: "Delete test Chart"


### PR DESCRIPTION
As discussed earlier, here is the extraction of the jobs steps in their own files, currently used on chart-nodejs

This may prepare the deletion of the jobs themselves if the chart-java project uses those steps only.

As is it should be backward-compatible, provided that the validation is not necessary when creating a new tag.

You'll notice that the previous chart cleanup is moved upfront and always exiting with 0