### PR TITLE
fix helm publish 

### DIFF
--- a/steps/charts/release.yaml
+++ b/steps/charts/release.yaml
@@ -41,5 +41,5 @@ steps:
       azureSubscription: ${{ parameters.serviceConnection }}
       scriptLocation: "inlineScript"
       inlineScript: |
-        CHART_FILE=$(ls ${{ parameters.chartName }}-*)
+        CHART_FILE=$(ls ${{ parameters.chartName }}*)
         az acr helm push --name ${{ parameters.acrName }} $CHART_FILE


### PR DESCRIPTION
Sorry in advance...this is a bit finger in the air!

Working on helmifying: https://github.com/hmcts/feature-toggle-api/tree/master/charts

The build fails with:

```
2019-01-17T11:59:21.8283313Z ls: cannot access 'charts/feature-toggle-api-*': No such file or directory
2019-01-17T11:59:22.5384678Z ERROR: az acr helm push: error: the following arguments are required: <CHART_PACKAGE>
2019-01-17T11:59:22.5510246Z usage: az acr helm push [-h] [--verbose] [--debug]
2019-01-17T11:59:22.5510681Z                         [--output {json,jsonc,table,tsv,yaml}]
2019-01-17T11:59:22.5510990Z                         [--query JMESPATH] --name REGISTRY_NAME [--force]
2019-01-17T11:59:22.5511296Z                         [--username USERNAME] [--password PASSWORD]
2019-01-17T11:59:22.5511768Z                         [--subscription _SUBSCRIPTION]
2019-01-17T11:59:22.5511909Z                         <CHART_PACKAGE>
2019-01-17T11:59:22.6182911Z [command]/usr/bin/az account clear
2019-01-17T11:59:23.3732759Z ##[error]Script failed with error: Error: /bin/bash failed with return code: 2
2019-01-17T11:59:23.3745076Z ##[section]Finishing: Helm Publish
```