### PR TITLE
Added Chartpath parameter

### DIFF
--- a/steps/charts/release.yaml
+++ b/steps/charts/release.yaml
@@ -7,6 +7,7 @@ parameters:
   chartName: ""
   chartReleaseName: ""
   chartNamespace: ""
+  chartPath: "./"
   helmVersion: "3.2.4"
 
 steps:
@@ -31,7 +32,7 @@ steps:
         helm repo add stable https://kubernetes-charts.storage.googleapis.com
         az acr helm repo add --name ${{ parameters.acrName }}
 
-  - script: helm dependency update ${{ parameters.chartName }}
+  - script: helm dependency update ${{ parameters.chartPath }}${{ parameters.chartName }}
     displayName: "Retrieve helm dependencies (if any)"
 
   - task: AzureCLI@1
@@ -40,11 +41,11 @@ steps:
       azureSubscription: ${{ parameters.registryServiceConnection }}
       scriptLocation: "inlineScript"
       inlineScript: |
-        rm -f $(ls ${{ parameters.chartName }}-[0-9]*)
+        rm -f $(ls ${{ parameters.chartPath }}${{ parameters.chartName }}-[0-9]*)
         echo "Building branch $(Build.SourceBranch)"
         tag=$(echo $(Build.SourceBranch) | cut -d'/' -f 3 | sed 's/v//')
         echo "publishing chart version $tag"
-        helm package ${{ parameters.chartName }} --version ${tag} --app-version ${tag}
+        helm package ${{ parameters.chartPath }}${{ parameters.chartName }} --version ${tag} --app-version ${tag}
 
   - task: AzureCLI@1
     displayName: "Helm Publish"
@@ -52,5 +53,5 @@ steps:
       azureSubscription: ${{ parameters.registryServiceConnection }}
       scriptLocation: "inlineScript"
       inlineScript: |
-        CHART_FILE=$(ls ${{ parameters.chartName }}-[0-9]*)
+        CHART_FILE=$(ls ${{ parameters.chartPath }}${{ parameters.chartName }}-[0-9]*)
         az acr helm push --name ${{ parameters.acrName }} $CHART_FILE

--- a/steps/charts/release.yaml
+++ b/steps/charts/release.yaml
@@ -53,5 +53,5 @@ steps:
       azureSubscription: ${{ parameters.registryServiceConnection }}
       scriptLocation: "inlineScript"
       inlineScript: |
-        CHART_FILE=$(ls ${{ parameters.chartPath }}${{ parameters.chartName }}-[0-9]*)
+        CHART_FILE=$(ls ${{ parameters.chartName }}-[0-9]*)
         az acr helm push --name ${{ parameters.acrName }} $CHART_FILE

--- a/steps/charts/validate.yaml
+++ b/steps/charts/validate.yaml
@@ -7,6 +7,7 @@ parameters:
   chartName: ""
   chartReleaseName: ""
   chartNamespace: ""
+  chartPath: "./"
   helmVersion: "3.2.4"
   helmInstallTimeout: "120"
   helmTestTimeout: "300"
@@ -36,7 +37,7 @@ steps:
         helm repo add stable https://kubernetes-charts.storage.googleapis.com
         az acr helm repo add --name ${{ parameters.acrName }}
 
-  - script: helm dependency update ${{ parameters.chartName }}
+  - script: helm dependency update ${{ parameters.chartPath }}${{ parameters.chartName }}
     displayName: "Retrieve helm dependencies (if any)"
 
   - script: helm delete --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} || true
@@ -45,10 +46,10 @@ steps:
   - script: sleep ${{ parameters.helmDeleteWait }}
     displayName: "Wait for previous chart resources to be deprovisioned"
 
-  - script: helm lint ${{ parameters.chartName }}
+  - script: helm lint ${{ parameters.chartPath }}${{ parameters.chartName }}
     displayName: "Helm Lint"
 
-  - script: helm install ${{ parameters.chartReleaseName }} ${{ parameters.chartName }} --namespace ${{ parameters.chartNamespace }} -f ${{ parameters.valuesFile }} --wait --timeout ${{ parameters.helmInstallTimeout }}s
+  - script: helm install ${{ parameters.chartReleaseName }} ${{ parameters.chartPath }}${{ parameters.chartName }} --namespace ${{ parameters.chartNamespace }} -f ${{ parameters.valuesFile }} --wait --timeout ${{ parameters.helmInstallTimeout }}s
     displayName: "Helm Install"
 
   - script: sleep ${{ parameters.helmInstallWait }}


### PR DESCRIPTION

### JIRA link (if applicable) ###



### Change description ###
Added a new chartpath parameter to support chart repositories with multiple folders.

The release and validate steps currently only supports single-level repositories e.g. hmcts/chart-java, hmcts/chart-chartname but not the new [sds helm chart](https://github.com/hmcts/sds-helm-charts) where multiple charts will sit under sub-folders of the root.

For existing single-level chart, the path will default to "./" which alllows CI validate and release tasks complete as normal while a custom path can be set as required for charts not located in the repository root.

Change tested with the [chart-azure-devops-agent ](https://dev.azure.com/hmcts/CNP/_build/results?buildId=96019&view=results)pipeline.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
