### PR TITLE
DTSPO-9047 - Publish terraform plan to ADO pipeline summary

### DIFF
--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -95,6 +95,7 @@ steps:
         -var builtFrom=$(Build.Repository.Name)
         -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
         -var-file $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)/environments/${{ parameters.environment }}/${{ parameters.environment }}.tfvars
+      publishPlanResults: '${{ parameters.component }}'
 
   - task: TerraformCLI@0
     displayName: Terraform apply ${{ parameters.component }}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-9047

### Change description ###
Adds terraform plan changes summary to Azure DevOps pipeline summary page
![image](https://user-images.githubusercontent.com/80516065/176422938-1bec49aa-004f-4ec6-8d8f-224d784136cc.png)
https://dev.azure.com/hmcts/CNP/_build/results?buildId=239418&view=results

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
