### PR TITLE
Add pipeline_tests.yaml

### DIFF
--- a/steps/pipeline_tests.yaml
+++ b/steps/pipeline_tests.yaml
@@ -1,0 +1,43 @@
+parameters:
+- name: environment
+  default: ''
+- name: domain_prefix
+  default: ''
+- name: playbook_file
+  default: 'pipeline-tests.yaml'
+- name: workingDirectory
+  default: ''
+- name: junit_output_dir
+  default: ''
+- name: root_domain
+  default: platform.hmcts.net
+
+steps:
+- task: Bash@3
+  displayName: Run pipeline tests
+  inputs:
+    targetType: 'inline'
+    script: |
+      mkdir junit
+      echo "localhost ansible_connection=local" > /tmp/hosts
+      ansible-playbook ${{ parameters.playbook_file }} -i /tmp/hosts
+    workingDirectory: '${{ parameters.workingDirectory }}'
+    failOnStderr: true
+  env:
+    ANSIBLE_LOCALHOST_WARNING: false
+    ANSIBLE_CALLBACKS_ENABLED: junit
+    JUNIT_FAIL_ON_IGNORE: true
+    JUNIT_OUTPUT_DIR: '${{ parameters.junit_output_dir }}'
+    ${{ if eq(parameters.environment, 'prod') }}:
+      GLOBAL_DOMAIN_NAME: '${{ parameters.root_domain }}'
+    ${{ else }}:
+      GLOBAL_DOMAIN_NAME: '${{ parameters.domain_prefix }}.${{ parameters.root_domain }}'
+
+- task: PublishTestResults@2
+  displayName: Publish pipeline tests
+  condition: always()
+  inputs:
+    testResultsFormat: 'JUnit'
+    failTaskOnFailedTests: true
+    testResultsFiles: '${{ parameters.junit_output_dir }}/pipeline-tests-*.*.xml'
+    testRunTitle: 'Platform Pipeline Tests (${{ parameters.environment }})'


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPO-9054](https://tools.hmcts.net/jira/browse/DTSPO-9054)


### Change description ###

Add pipeline tests ADO template to be used as part of other ADO pipelines (currently testing plum endpoints)
This template is utilised by https://github.com/hmcts/azure-platform-terraform/pull/1209 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
