### PR TITLE
Enhanced disallowed owner role checks to permit exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store

--- a/scripts/terraform-lint.tests.ps1
+++ b/scripts/terraform-lint.tests.ps1
@@ -33,14 +33,12 @@ else
           $matchResults = $result.Matches.Value
 
           foreach ($matchResult in $matchResults){
-            [array]$matchFound = @() 
+            [array]$testResults = @() 
             foreach($roleException in $roleExceptions) {
               $testResult = ($matchResult | Select-String -Pattern "role_definition_name.*=.\`"$roleException")
-              if (-not [string]::IsNullOrEmpty($testResult)) {
-                $matchFound += $true
-              }
+                $testResults += $testResult
             }
-            if ($matchFound -notcontains $true) {
+            if ([string]::IsNullOrEmpty($testResults)) {
               Write-Output "[ $matchResult ] is not a permitted Owner role"
               $badResultFound = $True
             }

--- a/scripts/terraform-lint.tests.ps1
+++ b/scripts/terraform-lint.tests.ps1
@@ -19,10 +19,34 @@ else
       }
     }
 
-    Context "Do not contain the 'Owner' role" {
-      It "<Instance> does not have owner role" -TestCases $TfTestCases {
+    Context "Do not contain a disallowed 'Owner' role" {
+      It "<Instance> does not have a disallowed 'Owner' role" -TestCases $TfTestCases {
           Param($Instance)
-           ((Get-Content -raw $Instance) | Select-String -Pattern "role_definition_name.*=.*Owner" ) | should BeNullOrEmpty
+
+          [array]$roleExceptions = (
+            "Azure Event Hubs Data Owner",
+            "Test Role Owner"
+          )
+          
+          [bool]$badResultFound = $False 
+          
+          $result = ((Get-Content -raw $Instance) | Select-String -Pattern "role_definition_name.*=.*Owner" -AllMatches) 
+          $matchResults = $result.Matches.Value
+
+          foreach ($matchResult in $matchResults){
+            [array]$matchFound = @() 
+            foreach($roleException in $roleExceptions) {
+              $testResult = ($matchResult | Select-String -Pattern "role_definition_name.*=.\`"$roleException")
+              if (-not [string]::IsNullOrEmpty($testResult)) {
+                $matchFound += $true
+              }
+            }
+            if ($matchFound -notcontains $true) {
+              Write-Output "[ $matchResult ] is not a permitted Owner role"
+              $badResultFound = $True
+            }
+          }
+          $badResultFound | Should -BeFalse
       }
     }
 

--- a/scripts/terraform-lint.tests.ps1
+++ b/scripts/terraform-lint.tests.ps1
@@ -24,8 +24,7 @@ else
           Param($Instance)
 
           [array]$roleExceptions = (
-            "Azure Event Hubs Data Owner",
-            "Test Role Owner"
+            "Azure Event Hubs Data Owner"
           )
           
           [bool]$badResultFound = $False 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-9664


### Change description ###
Added support for permitting exceptions to 'Owner' roles flagged by the pester test pipeline checks - this is to unblock pipeline upgrades in SOC repo, where the 'Azure Event Hubs Data Owner' is utilised and has been for a long period of time.

Code will loop through matching results of string match regex, and check if it matches any items within the '[array]$roleExceptions' list, then flag if no match is found. Output will tell user which role is not permitted.

Pester test results have been validated against the SOC repo [soc/modules/eventhub/roles.tf](https://github.com/hmcts/soc/blob/8da74e6325782e3853df61e7ecd78275fc6158f3/modules/eventhub/roles.tf)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
