### PR TITLE
DTSPO-9919 Remove no longer needed test

### DIFF
--- a/scripts/terraform-lint.tests.ps1
+++ b/scripts/terraform-lint.tests.ps1
@@ -19,34 +19,6 @@ else
       }
     }
 
-    Context "Do not contain a disallowed 'Owner' role" {
-      It "<Instance> does not have a disallowed 'Owner' role" -TestCases $TfTestCases {
-          Param($Instance)
-
-          [array]$roleExceptions = (
-            "Azure Event Hubs Data Owner"
-          )
-          
-          [bool]$badResultFound = $False 
-          
-          $result = ((Get-Content -raw $Instance) | Select-String -Pattern "role_definition_name.*=.*Owner" -AllMatches) 
-          $matchResults = $result.Matches.Value
-
-          foreach ($matchResult in $matchResults){
-            [array]$testResults = @() 
-            foreach($roleException in $roleExceptions) {
-              $testResult = ($matchResult | Select-String -Pattern "role_definition_name.*=.\`"$roleException")
-                $testResults += $testResult
-            }
-            if ([string]::IsNullOrEmpty($testResults)) {
-              Write-Output "[ $matchResult ] is not a permitted Owner role"
-              $badResultFound = $True
-            }
-          }
-          $badResultFound | Should -BeFalse
-      }
-    }
-
     $TfFolderTestCases=@()
     ((($TfFiles).DirectoryName | Select-Object -Unique)).ForEach{$TfFolderTestCases += @{Instance = $_}}
       Context "Are correctly formatted" {


### PR DESCRIPTION
This dates back to when service principals were first given the ability to delegate permissions, when the waters were just being tested. Previously permissions were all manual.

This is blocking https://github.com/hmcts/azure-enterprise/pull/18 which needs to grant the owner role

I think we can just remove this.