### PR TITLE
Use subscription already passed through

### DIFF
--- a/scripts/unlock-tf-state.sh
+++ b/scripts/unlock-tf-state.sh
@@ -3,16 +3,10 @@ set -e
 
 storage_account_name=$1
 stateFilePath=$2
-container=${3:-subscription-tfstate}
+terraformInitSubscription=$3
+container=${4:-subscription-tfstate}
 
-if az account list | grep "HMCTS-CONTROL"
-then
-  subscription="HMCTS-CONTROL"
-else
-  subscription="DCD-RBAC-CONTROL"
-fi
-
-az account set --subscription $subscription
+az account set --subscription $terraformInitSubscription
 
 export AZURE_STORAGE_KEY=$(az storage account keys list  -n $storage_account_name --query [0].value -o tsv)
 

--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -187,4 +187,4 @@ steps:
       scriptLocation: scriptPath
       azureSubscription: ${{ parameters.serviceConnection }}
       scriptPath: $(System.DefaultWorkingDirectory)/cnp-azuredevops-libraries/scripts/unlock-tf-state.sh
-      arguments: $(controlStorageAccount) "${{ parameters.location }}/${{ parameters.product }}/$(buildRepoSuffix)/${{ parameters.environment }}/${{ parameters.component }}/terraform.tfstate"
+      arguments: $(controlStorageAccount) "${{ parameters.location }}/${{ parameters.product }}/$(buildRepoSuffix)/${{ parameters.environment }}/${{ parameters.component }}/terraform.tfstate" ${{ parameters.terraformInitSubscription }}


### PR DESCRIPTION
No more guessing

Tested in https://github.com/hmcts/azure-enterprise/pull/23

Turns out we were already passing this subscription in as a parameter so guessing it was silly.