### PR TITLE
Switch to use tfswitch instead of tfenv

### DIFF
--- a/steps/install-use-tfswitch.yaml
+++ b/steps/install-use-tfswitch.yaml
@@ -5,7 +5,7 @@ parameters:
   - name: tfswitchArgs
     default: ''
   - name: tfswitchVersion
-    default: 'latest'
+    default: '0.13.1300'
   - name: tfswitchPath
     default: '~/.local/bin'
 steps:

--- a/steps/install-use-tfswitch.yaml
+++ b/steps/install-use-tfswitch.yaml
@@ -14,5 +14,7 @@ steps:
       script: |
         curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash -s -- -b  ~/.local/bin latest
         set -x
+        # Make sure ~/.local/bin is set for both root and non-root based agents (self-hosted etc)
+        echo '##vso[task.prependpath]$(HOME)/.local/bin'
         tfswitch ${{ parameters.tfswitchArgs }}
       workingDirectory: ${{ parameters.workingDirectory}}

--- a/steps/install-use-tfswitch.yaml
+++ b/steps/install-use-tfswitch.yaml
@@ -1,0 +1,18 @@
+---
+parameters:
+  - name: workingDirectory
+    default: $(System.DefaultWorkingDirectory)
+  - name: tfswitchArgs
+    default: ''
+steps:
+  - task: Bash@3
+    displayName: Terraform install (tfswitch)
+    env:
+      BINDIR: ~/.local/bin
+    inputs:
+      targetType: 'inline'
+      script: |
+        curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash -s -- -b  ~/.local/bin latest
+        set -x
+        tfswitch ${{ parameters.tfswitchArgs }}
+      workingDirectory: ${{ parameters.workingDirectory}}

--- a/steps/install-use-tfswitch.yaml
+++ b/steps/install-use-tfswitch.yaml
@@ -4,6 +4,10 @@ parameters:
     default: $(System.DefaultWorkingDirectory)
   - name: tfswitchArgs
     default: ''
+  - name: tfswitchVersion
+    default: 'latest'
+  - name: tfswitchPath
+    default: '~/.local/bin'
 steps:
   - task: Bash@3
     displayName: Terraform install (tfswitch)
@@ -12,9 +16,12 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-        curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash -s -- -b  ~/.local/bin latest
+        curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash -s -- -b  ${{ parameters.tfswitchPath }} ${{ parameters.tfswitchVersion }}
         set -x
         # Make sure ~/.local/bin is set for both root and non-root based agents (self-hosted etc)
+        # Prepend PATH for other ADO tasks
         echo '##vso[task.prependpath]$(HOME)/.local/bin'
+        # Prepend PATH for current ADO task
+        export PATH=$HOME/.local/bin:$PATH
         tfswitch ${{ parameters.tfswitchArgs }}
       workingDirectory: ${{ parameters.workingDirectory}}

--- a/steps/terraform-precheck.yaml
+++ b/steps/terraform-precheck.yaml
@@ -19,10 +19,9 @@ steps:
   - checkout: cnp-azuredevops-libraries
   - template: ./set-build-repo-suffix-env-var.yaml
 
-  - task: Bash@3
-    displayName: Terraform install (tfenv)
-    inputs:
-      filePath: $(System.DefaultWorkingDirectory)/cnp-azuredevops-libraries/scripts/tfenv-install-terraform.sh
+  - template: ./install-use-tfswitch.yaml
+    parameters:
+      tfswitchArgs: -b ~/.local/bin/terraform --latest
       workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
 
   - task: AzureKeyVault@1

--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -89,11 +89,10 @@ steps:
       keyVaultName: 'infra-vault-nonprod'
       secretsFilter: 'github-api-token'
 
-  - task: Bash@3
-    displayName: Terraform install (tfenv)
-    inputs:
-      filePath: $(System.DefaultWorkingDirectory)/cnp-azuredevops-libraries/scripts/tfenv-install-terraform.sh
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+  - template: ./install-use-tfswitch.yaml
+    parameters:
+      tfswitchArgs: -b ~/.local/bin/terraform
+      workingDirectory: '$(System.DefaultWorkingDirectory)/$(buildRepoSuffix)/components/${{ parameters.component }}'
 
   - task: Bash@3
     displayName: Build resource values


### PR DESCRIPTION
### JIRA link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-9111
https://tools.hmcts.net/jira/browse/DTSPO-9915


### Change description ###

This will replace tfenv with tfswitch. (https://github.com/warrensbox/terraform-switcher)

tfswitch supports reading directly from provider files in terraform code which removes the need for .terraform-version file in repositories and maintaining it in two places.

Sample test run: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=304834&view=results

Sample test removal of `.terraform-version` : https://github.com/hmcts/aks-sds-deploy/pull/328
Sample run: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=304879&view=results

Another unplanned benefit of using tfswitch and workingDirectory set to component is that each component can be set to it's own version of terraform.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
