### PR TITLE
Allow skipping prevent parallel runs step when planning

### DIFF
--- a/steps/terraform-precheck.yaml
+++ b/steps/terraform-precheck.yaml
@@ -14,6 +14,10 @@ parameters:
   - name: serviceConnection
     default: ''
 
+  - name: overrideAction
+    default: apply
+
+
 steps:
   - checkout: self
   - checkout: cnp-azuredevops-libraries
@@ -48,6 +52,7 @@ steps:
 
   - task: Bash@3
     displayName: Prevent parallel run
+    condition: and(succeeded(), ne('${{ parameters.overrideAction }}', 'plan'))
     env:
       thisbuild: $(Build.BuildId)
       pipelinedefinition: $(System.DefinitionId)

--- a/steps/terraform-precheck.yaml
+++ b/steps/terraform-precheck.yaml
@@ -17,7 +17,6 @@ parameters:
   - name: overrideAction
     default: apply
 
-
 steps:
   - checkout: self
   - checkout: cnp-azuredevops-libraries

--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -146,12 +146,14 @@ steps:
           -var builtFrom=$(Build.Repository.Name)
           -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
           -var-file "$(System.DefaultWorkingDirectory)/$(buildRepoSuffix)/environments/${{ parameters.environment }}/$(tfVarsName).tfvars"
+          -lock=false
       ${{ elseif eq(parameters['tfVarsFile'], 'NULL') }}:
         commandOptions: >
           -out tfplan-$(tfPlanName)
           -var env=${{ parameters.environment }}
           -var builtFrom=$(Build.Repository.Name)
           -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
+          -lock=false
       ${{ else }}:
         commandOptions: >
           -out tfplan-$(tfPlanName)
@@ -159,7 +161,7 @@ steps:
           -var builtFrom=$(Build.Repository.Name)
           -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
           -var-file "${{ parameters.tfVarsFile }}"
-
+          -lock=false
   - task: Bash@3
     displayName: Publish Plan to GitHub - ${{ parameters.component }}
     condition: and(succeeded(), in('${{ parameters.overrideAction }}', 'plan', 'apply'), ne(variables['System.PullRequest.PullRequestNumber'], '') )

--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -139,32 +139,29 @@ steps:
       environmentServiceName: ${{ parameters.serviceConnection }}
       runAzLogin: true
       publishPlanResults: "$(tfPlanName)"
-      commandOptions: >
-        -out tfplan-$(tfPlanName)
-        -var env=${{ parameters.environment }}
-        -var builtFrom=$(Build.Repository.Name)
-        -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
-        -lock=false
       ${{ if eq(parameters['tfVarsFile'], '') }}:
-        -var-file "$(System.DefaultWorkingDirectory)/$(buildRepoSuffix)/environments/${{ parameters.environment }}/$(tfVarsName).tfvars"
-      ${{ elseif ne(parameters['tfVarsFile'], 'NULL') }}:
-        -var-file "${{ parameters.tfVarsFile }}"
-
-#      ${{ elseif eq(parameters['tfVarsFile'], 'NULL') }}:
-#        commandOptions: >
-#          -out tfplan-$(tfPlanName)
-#          -var env=${{ parameters.environment }}
-#          -var builtFrom=$(Build.Repository.Name)
-#          -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
-#          -lock=false
-#      ${{ else }}:
-#        commandOptions: >
-#          -out tfplan-$(tfPlanName)
-#          -var env=${{ parameters.environment }}
-#          -var builtFrom=$(Build.Repository.Name)
-#          -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
-#          -var-file "${{ parameters.tfVarsFile }}"
-#          -lock=false
+        commandOptions: >
+          -out tfplan-$(tfPlanName)
+          -var env=${{ parameters.environment }}
+          -var builtFrom=$(Build.Repository.Name)
+          -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
+          -var-file "$(System.DefaultWorkingDirectory)/$(buildRepoSuffix)/environments/${{ parameters.environment }}/$(tfVarsName).tfvars"
+          -lock=false
+      ${{ elseif eq(parameters['tfVarsFile'], 'NULL') }}:
+        commandOptions: >
+          -out tfplan-$(tfPlanName)
+          -var env=${{ parameters.environment }}
+          -var builtFrom=$(Build.Repository.Name)
+          -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
+          -lock=false
+      ${{ else }}:
+        commandOptions: >
+          -out tfplan-$(tfPlanName)
+          -var env=${{ parameters.environment }}
+          -var builtFrom=$(Build.Repository.Name)
+          -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
+          -var-file "${{ parameters.tfVarsFile }}"
+          -lock=false
   - task: Bash@3
     displayName: Publish Plan to GitHub - ${{ parameters.component }}
     condition: and(succeeded(), in('${{ parameters.overrideAction }}', 'plan', 'apply'), ne(variables['System.PullRequest.PullRequestNumber'], '') )

--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -139,29 +139,32 @@ steps:
       environmentServiceName: ${{ parameters.serviceConnection }}
       runAzLogin: true
       publishPlanResults: "$(tfPlanName)"
+      commandOptions: >
+        -out tfplan-$(tfPlanName)
+        -var env=${{ parameters.environment }}
+        -var builtFrom=$(Build.Repository.Name)
+        -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
+        -lock=false
       ${{ if eq(parameters['tfVarsFile'], '') }}:
-        commandOptions: >
-          -out tfplan-$(tfPlanName)
-          -var env=${{ parameters.environment }}
-          -var builtFrom=$(Build.Repository.Name)
-          -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
-          -var-file "$(System.DefaultWorkingDirectory)/$(buildRepoSuffix)/environments/${{ parameters.environment }}/$(tfVarsName).tfvars"
-          -lock=false
-      ${{ elseif eq(parameters['tfVarsFile'], 'NULL') }}:
-        commandOptions: >
-          -out tfplan-$(tfPlanName)
-          -var env=${{ parameters.environment }}
-          -var builtFrom=$(Build.Repository.Name)
-          -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
-          -lock=false
-      ${{ else }}:
-        commandOptions: >
-          -out tfplan-$(tfPlanName)
-          -var env=${{ parameters.environment }}
-          -var builtFrom=$(Build.Repository.Name)
-          -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
-          -var-file "${{ parameters.tfVarsFile }}"
-          -lock=false
+        -var-file "$(System.DefaultWorkingDirectory)/$(buildRepoSuffix)/environments/${{ parameters.environment }}/$(tfVarsName).tfvars"
+      ${{ elseif ne(parameters['tfVarsFile'], 'NULL') }}:
+        -var-file "${{ parameters.tfVarsFile }}"
+
+#      ${{ elseif eq(parameters['tfVarsFile'], 'NULL') }}:
+#        commandOptions: >
+#          -out tfplan-$(tfPlanName)
+#          -var env=${{ parameters.environment }}
+#          -var builtFrom=$(Build.Repository.Name)
+#          -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
+#          -lock=false
+#      ${{ else }}:
+#        commandOptions: >
+#          -out tfplan-$(tfPlanName)
+#          -var env=${{ parameters.environment }}
+#          -var builtFrom=$(Build.Repository.Name)
+#          -var product=${{ parameters.product }} ${{ parameters.planCommandOptions }}
+#          -var-file "${{ parameters.tfVarsFile }}"
+#          -lock=false
   - task: Bash@3
     displayName: Publish Plan to GitHub - ${{ parameters.component }}
     condition: and(succeeded(), in('${{ parameters.overrideAction }}', 'plan', 'apply'), ne(variables['System.PullRequest.PullRequestNumber'], '') )


### PR DESCRIPTION
### Change description ###
Prevent parallel runs is causing pipelines to queue up even when just running plans. This change doesn't change the default behaviour, but allows the disablement of the `prevent parallel runs` step when running a plan. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
