### PR TITLE
Ensure python has requests installed when working on self hosted ADO

### DIFF
--- a/steps/terraform-precheck.yaml
+++ b/steps/terraform-precheck.yaml
@@ -55,6 +55,7 @@ steps:
     inputs:
       targetType: inline
       script: |
+        python3 -m pip install requests && \
         python3 $(System.DefaultWorkingDirectory)/cnp-azuredevops-libraries/scripts/ado-build-check.py \
         --pat $(azure-devops-token) \
         --buildid $(Build.BuildId) \


### PR DESCRIPTION



### Change description ###

Ensure python has requests installed when working on self hosted ADO

Sample working rest run https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=307354&view=logs&j=57216404-96e9-5890-f3bc-8ea7b708bdb5&t=bbf2ac4a-d73f-543c-8698-3d0b4759b237 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
