### PR TITLE
DTSPO-12032: Revert logic for apply in cnp library

### DIFF
--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -189,7 +189,7 @@ steps:
       env: ${{ parameters.terraformEnvironmentVariables  }}
     condition: |
       or(
-      and(succeeded(), eq('${{ parameters.overrideAction }}', 'apply')),
+      and(succeeded(), eq(variables['isMain'], true), eq('${{ parameters.overrideAction }}', 'apply')),
       and(succeeded(), eq(variables['isMain'], true), eq(variables['isAutoTriggered'], true))
       )
     inputs:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-12032


### Change description ###
Reverting back to original logic as this would now allow every other repo using the library to be able to apply from branch which is what we don't want.

May i suggest an addition to the `or` condition where the logic could be added e.g.
`and(succeeded(), eq('${{ parameters.overrideAction }}', 'apply'), eq('${{ parameters.applyOnBranch }}', 'true'))`

So that if a project/repo has need to specifically `apply` on branch, then that project can pass the additional parameter to facilitate this.

Default value for `applyOnBranch` would be false so other repos are still happy remain as before where `apply` only happens either on `main` or on merge of the `main` branch.

Happy for further conversations or suggestion, and happy for that to be implemented as well 😜
@louisehuyton , @msl8r , @timja 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
