### PR TITLE
Allow forcing debug of prevent parallel job tasks

### DIFF
--- a/scripts/ado-build-check.py
+++ b/scripts/ado-build-check.py
@@ -66,7 +66,7 @@ ado_definition_url = (
     + "/_apis/build/builds?api-version=5.1&definitions="
     + f"{pipelineid}"
 )
-logger.info(f"ADO Pipeline definition URL is : {ado_definition_url}")
+logger.info(f'ADO Pipeline definition URL is : "{ado_definition_url}"')
 logger.info(f"Provided build id is : {buildid}")
 
 

--- a/steps/terraform-precheck.yaml
+++ b/steps/terraform-precheck.yaml
@@ -17,6 +17,11 @@ parameters:
   - name: overrideAction
     default: apply
 
+  - name: forcePreventParallelJobRun
+    displayName: Always force prevent parallem run job
+    type: boolean
+    default: false
+
 steps:
   - checkout: self
   - checkout: cnp-azuredevops-libraries
@@ -55,6 +60,7 @@ steps:
     condition: |
       and(succeeded(),
         or(
+            eq(${{ parameters.forcePreventParallelJobRun }}, true),
             and(
                 ne('${{ parameters.overrideAction }}', 'plan'),
                 eq(variables['isAutoTriggered'], false)
@@ -72,9 +78,10 @@ steps:
     inputs:
       targetType: inline
       script: |
+        set -x
         python3 $(System.DefaultWorkingDirectory)/cnp-azuredevops-libraries/scripts/ado-build-check.py \
-        --pat $(azure-devops-token) \
-        --buildid $(Build.BuildId) \
-        --organization hmcts \
-        --project $(System.TeamProject) \
-        --pipelineid $(System.DefinitionId)
+        --pat "$(azure-devops-token)" \
+        --buildid "$(Build.BuildId)" \
+        --organization "hmcts" \
+        --project "$(System.TeamProject)" \
+        --pipelineid "$(System.DefinitionId)"

--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -62,6 +62,11 @@ parameters:
   - name: baseDirectory
     default: ''
 
+  - name: forcePreventParallelJobRun
+    displayName: Always force prevent parallem run job
+    type: boolean
+    default: false
+
 
 steps:
   - checkout: self


### PR DESCRIPTION
### Change description ###

This change will:

- allow to debug parallel job run when running terraform plan (by setting the `forcePreventParallelJobRun` parameter to true (defautls to false)
- will display bash debug when running parallel job script for troubleshooting purposes
- quite the script parameters so that it works with two part worded projects aka "Security Engineering" etc

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
