### PR TITLE
Install 'packaging' module before script is run

### DIFF
--- a/steps/terraform-version-nagger.yaml
+++ b/steps/terraform-version-nagger.yaml
@@ -17,6 +17,7 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
+        pip3 install packaging
         python3 $(System.DefaultWorkingDirectory)/cnp-azuredevops-libraries/scripts/ado-terraform-nagger.py
       workingDirectory: ${{ parameters.workingDirectory}}
     env:


### PR DESCRIPTION
https://dev.azure.com/hmcts/CNP/_build/results?buildId=349427&view=logs&j=fc72dc6b-e2a2-56c3-f0a3-e38bccfb201a&t=8270a577-b78b-5f52-71c6-e32f2c861cfd 

Causing error: 
```
Traceback (most recent call last):
  File "/azp/_work/1/s/cnp-azuredevops-libraries/scripts/ado-terraform-nagger.py", line 9, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
##[error]Bash exited with code '1'.

```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
