### PR TITLE
Update test message

### DIFF
--- a/scripts/terraform-lint.tests.ps1
+++ b/scripts/terraform-lint.tests.ps1
@@ -22,7 +22,7 @@ else
     $TfFolderTestCases=@()
     ((($TfFiles).DirectoryName | Select-Object -Unique)).ForEach{$TfFolderTestCases += @{Instance = $_}}
       Context "Are correctly formatted" {
-        It "Terraform fmt command has been run on all files in <Instance>, to rewrite files to a canonical format and style." -TestCases $TfFolderTestCases {
+        It "All files in <Instance> are correctly formatted. By running 'terraform fmt'" -TestCases $TfFolderTestCases {
           Param($Instance)
           Invoke-Expression "terraform fmt -check=true $Instance"  | should -BeNullOrEmpty
       }

--- a/scripts/terraform-lint.tests.ps1
+++ b/scripts/terraform-lint.tests.ps1
@@ -22,7 +22,7 @@ else
     $TfFolderTestCases=@()
     ((($TfFiles).DirectoryName | Select-Object -Unique)).ForEach{$TfFolderTestCases += @{Instance = $_}}
       Context "Are correctly formatted" {
-        It "All files in <Instance> are correctly formatted" -TestCases $TfFolderTestCases {
+        It "Terraform fmt command has been run on all files in <Instance>, to rewrite files to a canonical format and style." -TestCases $TfFolderTestCases {
           Param($Instance)
           Invoke-Expression "terraform fmt -check=true $Instance"  | should -BeNullOrEmpty
       }


### PR DESCRIPTION
Can we make this failure more meaningful straight away when it fails? 

This would look more understandable to new people than the current one in my opinion and point straight to `terraform fmt` as the resolution
![image](https://github.com/hmcts/cnp-azuredevops-libraries/assets/47995122/a22a3f62-247a-4999-b5af-51b7e1551692)



**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
