### PR TITLE
fix: install pester if not already available

### DIFF
--- a/scripts/pester-tests.ps1
+++ b/scripts/pester-tests.ps1
@@ -1,1 +1,4 @@
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+  Install-Module -Name Pester -MaximumVersion 5.4.1 -Force -Verbose -Scope CurrentUser
+}
 Invoke-Pester ../ -OutputFormat NUnitXml -OutputFile ./TEST-CI.xml -EnableExit

--- a/scripts/pester-tests.ps1
+++ b/scripts/pester-tests.ps1
@@ -1,4 +1,6 @@
+$PESTER_VERSION=5.4.1
+
 if (-Not (Get-Module -ListAvailable -Name Pester)) {
-  Install-Module -Name Pester -MaximumVersion 5.4.1 -Force -Verbose -Scope CurrentUser
+  Install-Module -Name Pester -MaximumVersion $PESTER_VERSION -Force -Verbose -Scope CurrentUser
 }
 Invoke-Pester ../ -OutputFormat NUnitXml -OutputFile ./TEST-CI.xml -EnableExit

--- a/updatecli/updatecli.d/pester.yaml
+++ b/updatecli/updatecli.d/pester.yaml
@@ -34,8 +34,8 @@ targets:
     spec:
       files:
         - scripts/pester-tests.ps1
-      matchpattern: '\$PESTER_VERSION=(\d+\.)?(\d+\.)?(\*|\d+)'
-      content: '$PESTER_VERSION={{ source `latestPesterImageVersion` }}'
+      matchpattern: 'PESTER_VERSION=(\d+\.)?(\d+\.)?(\*|\d+)'
+      content: 'PESTER_VERSION={{ source `latestPesterImageVersion` }}'
 
 pullrequests:
   setPesterImageVersion:

--- a/updatecli/updatecli.d/pester.yaml
+++ b/updatecli/updatecli.d/pester.yaml
@@ -34,8 +34,8 @@ targets:
     spec:
       files:
         - scripts/pester-tests.ps1
-      matchpattern: '-MaximumVersion (\d+\.)?(\d+\.)?(\*|\d+)'
-      content: '-MaximumVersion {{ source `latestPesterImageVersion` }}'
+      matchpattern: '$PESTER_VERSION=(\d+\.)?(\d+\.)?(\*|\d+)'
+      content: '$PESTER_VERSION={{ source `latestPesterImageVersion` }}'
 
 pullrequests:
   setPesterImageVersion:

--- a/updatecli/updatecli.d/pester.yaml
+++ b/updatecli/updatecli.d/pester.yaml
@@ -34,7 +34,7 @@ targets:
     spec:
       files:
         - scripts/pester-tests.ps1
-      matchpattern: '$PESTER_VERSION=(\d+\.)?(\d+\.)?(\*|\d+)'
+      matchpattern: '\$PESTER_VERSION=(\d+\.)?(\d+\.)?(\*|\d+)'
       content: '$PESTER_VERSION={{ source `latestPesterImageVersion` }}'
 
 pullrequests:


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
The install pester CmdLet was removed as Pester is installed on Microsoft hosted agents. It isn't on self-hosted. Check to see if it is available, if not install it.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
