### PR TITLE
DTSPO-7962: Config flexibility update

### DIFF
--- a/steps/acr-build.yaml
+++ b/steps/acr-build.yaml
@@ -25,9 +25,9 @@ steps:
       eq(parameters['customImageTag'], '')
     )
 
-# With custom tag: Set the tag to a custom provided tag
+# With custom tag: Set the tag to a custom provided tag label
 - script: |
-    echo '##vso[task.setvariable variable=imageTag]${{ parameters['customImageTag'] }}"
+    echo "##vso[task.setvariable variable=imageTag]${{ parameters['customImageTag'] }}"
   displayName: 'Set Image Tag: Custom'
   condition: ne(parameters['customImageTag'], '')
 

--- a/steps/acr-build.yaml
+++ b/steps/acr-build.yaml
@@ -1,6 +1,7 @@
 parameters:
   serviceConnection: ''
   buildPath: ''
+  customImageTag: ''
 
 steps:
 
@@ -8,13 +9,27 @@ steps:
 - script: |
     echo '##vso[task.setvariable variable=imageTag]pr-$(System.PullRequest.PullRequestNumber)'
   displayName: 'Set Image Tag: Pull Request'
-  condition: eq(variables['Build.Reason'], 'PullRequest')
+  condition: |
+    and(
+      eq(variables['Build.Reason'], 'PullRequest'),
+      eq(parameters['customImageTag'], '')
+    )
 
 # Everything else: Set the tag to the branch name
 - script: |
     echo '##vso[task.setvariable variable=imageTag]$(Build.SourceBranchName)'
   displayName: 'Set Image Tag: Branch'
-  condition: ne(variables['Build.Reason'], 'PullRequest')
+  condition: |
+    and(
+      ne(variables['Build.Reason'], 'PullRequest'),
+      eq(parameters['customImageTag'], '')
+    )
+
+# With custom tag: Set the tag to a custom provided tag
+- script: |
+    echo '##vso[task.setvariable variable=imageTag]${{ parameters['customImageTag'] }}"
+  displayName: 'Set Image Tag: Custom'
+  condition: ne(parameters['customImageTag'], '')
 
 #
 # ACR Build


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-7962


### Change description ###
Desire the capability to passing in custom image tag names for the version reporter service images built via the version reporter pipeline.

Other that tagging using the pr branch name id like to be able to pass something like a PR number or some other custom name so i can easily differentiate the various images that would be build via the same repo.

Would like to be able to control the output e.g. instead of

```
2023/06/17 12:15:37 Successfully pushed image: sdshmctspublic.azurecr.io/hmcts/version-reporter-services:DTSPO-7962-refactor

- image:
    registry: sdshmctspublic.azurecr.io
    repository: hmcts/version-reporter-services
    tag: DTSPO-7962-refactor
    digest: ...
```

id like to be able to pass say a PR number or reportname and pr number or just latest to see something like:

```
2023/06/17 12:15:37 Successfully pushed image: sdshmctspublic.azurecr.io/hmcts/version-reporter-services:DTSPO-7962-refactor

- image:
    registry: sdshmctspublic.azurecr.io
    repository: hmcts/version-reporter-services
    tag: (pr-23 | helmreport-pr-23 | latest)
    digest: ...
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
