### PR TITLE
Update keyvault read script

### DIFF
--- a/steps/keyvault-read.yaml
+++ b/steps/keyvault-read.yaml
@@ -21,7 +21,7 @@ steps:
     
       upperCaseEnv=$(echo "${{ parameters.environment }}" | tr "[:lower:]" "[:upper:]")
 
-      $buildRepoSuffix="${{ parameters.buildRepoSuffix }}"
+      buildRepoSuffix=$(echo "${{ parameters.buildRepoSuffix }}")
 
       echo $buildRepoSuffix
 

--- a/steps/keyvault-read.yaml
+++ b/steps/keyvault-read.yaml
@@ -8,6 +8,7 @@ parameters:
   keyVaultVariableName: 'controlKeyVault'
   envVariableName: 'env'
   buildRepoSuffix: ''
+  component: ''
 
 steps:
 
@@ -21,44 +22,65 @@ steps:
     
       upperCaseEnv=$(echo "${{ parameters.environment }}" | tr "[:lower:]" "[:upper:]")
 
+      component=$(echo "${{ parameters.component }}")
+
+      echo COMPONENT: $component
+
       buildRepoSuffix=$(echo "${{ parameters.buildRepoSuffix }}")
 
-      echo $buildRepoSuffix
+      echo REPO: $buildRepoSuffix
 
       case "$buildRepoSuffix" in
           aks-cft-deploy)
-              case "$upperCaseEnv" in
-                  AAT)
-                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-STG'].id" -o tsv)
-                      ;;
-                  PERFTEST)
-                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-TEST'].id" -o tsv)
-                      ;;
-                  PREVIEW)
-                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-DEV'].id" -o tsv)
-                      ;;
-                  PTL)
-                      SUB_ID=$(az account list --query "[?name=='DTS-CFTPTL-INTSVC'].id" -o tsv)
-                      ;;
-                  PTLSBOX)
-                      SUB_ID=$(az account list --query "[?name=='DTS-CFTSBOX-INTSVC'].id" -o tsv)
-                      ;;
+                case "$component" in 
+                  network)
+                    SUB_ID=$(az account show --query id -o tsv)
+                    ;;
                   *)
-                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-$upperCaseEnv'].id" -o tsv)
-                      ;;
-              esac
-              ;;
+                    case "$upperCaseEnv" in
+                        AAT)
+                            SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-STG'].id" -o tsv)
+                            ;;
+                        PERFTEST)
+                            SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-TEST'].id" -o tsv)
+                            ;;
+                        PREVIEW)
+                            SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-DEV'].id" -o tsv)
+                            ;;
+                        PTL)
+                            SUB_ID=$(az account list --query "[?name=='DTS-CFTPTL-INTSVC'].id" -o tsv)
+                            ;;
+                        PTLSBOX)
+                            SUB_ID=$(az account list --query "[?name=='DTS-CFTSBOX-INTSVC'].id" -o tsv)
+                            ;;
+                        *)
+                            SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-$upperCaseEnv'].id" -o tsv)
+                            ;;
+                    esac
+                    ;;
+                esac
+                ;;
           aks-sds-deploy)
-              case "$upperCaseEnv" in
-                  PTL)
-                      SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICESPTL'].id" -o tsv)
-                      ;;
-                  PTLSBOX)
-                      SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICESPTL-SBOX'].id" -o tsv)
-                      ;;
+              case "$component" in 
+                  network)
+                    SUB_ID=$(az account show --query id -o tsv)
+                    ;;
                   *)
-                      SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICES-$upperCaseEnv'].id" -o tsv)
-                      ;;
+                    case "$upperCaseEnv" in
+                        PTL)
+                            SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICESPTL'].id" -o tsv)
+                            ;;
+                        PTLSBOX)
+                            SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICESPTL-SBOX'].id" -o tsv)
+                            ;;
+                        *)
+                            SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICES-$upperCaseEnv'].id" -o tsv)
+                            ;;
+                    esac
+                    ;;
+                    *)
+                    SUB_ID=$(az account show --query id -o tsv)
+                    ;;
               esac
               ;;
       esac
@@ -67,11 +89,11 @@ steps:
 
       SUB_NAME=$(az account list --query "[?id=='$SUB_ID'].name" -o tsv)
 
-      echo $SUB_NAME
+      echo SUB_NAME: $SUB_NAME
 
-      echo $SUB_ID
+      echo SUB_ID: $SUB_ID
       echo "##vso[task.setvariable variable=${{ parameters.subscriptionIdVariableName }}]$SUB_ID"
-      echo $TENANT_ID
+      echo TENANT_ID: $TENANT_ID
       echo "##vso[task.setvariable variable=${{ parameters.tenantIdVariableName }}]$TENANT_ID"
 
       FIRST=$(echo $SUB_ID | cut -c 1-8)

--- a/steps/keyvault-read.yaml
+++ b/steps/keyvault-read.yaml
@@ -8,7 +8,6 @@ parameters:
   keyVaultVariableName: 'controlKeyVault'
   envVariableName: 'env'
   buildRepoSuffix: ''
-  component: ''
 
 steps:
 
@@ -22,66 +21,48 @@ steps:
     
       upperCaseEnv=$(echo "${{ parameters.environment }}" | tr "[:lower:]" "[:upper:]")
 
-      component=$(echo "${{ parameters.component }}")
-
-      echo COMPONENT: $component
-
       buildRepoSuffix=$(echo "${{ parameters.buildRepoSuffix }}")
 
-      echo REPO: $buildRepoSuffix
+      echo BUILD_REPO: $buildRepoSuffix
 
       case "$buildRepoSuffix" in
           aks-cft-deploy)
-                case "$component" in 
-                  network)
-                    SUB_ID=$(az account show --query id -o tsv)
-                    ;;
+              case "$upperCaseEnv" in
+                  AAT)
+                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-STG'].id" -o tsv)
+                      ;;
+                  PERFTEST)
+                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-TEST'].id" -o tsv)
+                      ;;
+                  PREVIEW)
+                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-DEV'].id" -o tsv)
+                      ;;
+                  PTL)
+                      SUB_ID=$(az account list --query "[?name=='DTS-CFTPTL-INTSVC'].id" -o tsv)
+                      ;;
+                  PTLSBOX)
+                      SUB_ID=$(az account list --query "[?name=='DTS-CFTSBOX-INTSVC'].id" -o tsv)
+                      ;;
                   *)
-                    case "$upperCaseEnv" in
-                        AAT)
-                            SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-STG'].id" -o tsv)
-                            ;;
-                        PERFTEST)
-                            SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-TEST'].id" -o tsv)
-                            ;;
-                        PREVIEW)
-                            SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-DEV'].id" -o tsv)
-                            ;;
-                        PTL)
-                            SUB_ID=$(az account list --query "[?name=='DTS-CFTPTL-INTSVC'].id" -o tsv)
-                            ;;
-                        PTLSBOX)
-                            SUB_ID=$(az account list --query "[?name=='DTS-CFTSBOX-INTSVC'].id" -o tsv)
-                            ;;
-                        *)
-                            SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-$upperCaseEnv'].id" -o tsv)
-                            ;;
-                    esac
-                    ;;
-                esac
-                ;;
-          aks-sds-deploy)
-              case "$component" in 
-                  network)
-                    SUB_ID=$(az account show --query id -o tsv)
-                    ;;
-                  *)
-                    case "$upperCaseEnv" in
-                        PTL)
-                            SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICESPTL'].id" -o tsv)
-                            ;;
-                        PTLSBOX)
-                            SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICESPTL-SBOX'].id" -o tsv)
-                            ;;
-                        *)
-                            SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICES-$upperCaseEnv'].id" -o tsv)
-                            ;;
-                    esac
-                    ;;
-                    *)
-                    SUB_ID=$(az account show --query id -o tsv)
-                    ;;
+                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-$upperCaseEnv'].id" -o tsv)
+                      ;;
               esac
+              ;;
+          aks-sds-deploy)
+              case "$upperCaseEnv" in
+                  PTL)
+                      SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICESPTL'].id" -o tsv)
+                      ;;
+                  PTLSBOX)
+                      SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICESPTL-SBOX'].id" -o tsv)
+                      ;;
+                  *)
+                      SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICES-$upperCaseEnv'].id" -o tsv)
+                      ;;
+              esac
+              ;;
+            *)
+              SUB_ID=$(az account show --query id -o tsv)
               ;;
       esac
 

--- a/steps/keyvault-read.yaml
+++ b/steps/keyvault-read.yaml
@@ -20,9 +20,9 @@ steps:
     
       upperCaseEnv=$(echo "${{ parameters.environment }}" | tr "[:lower:]" "[:upper:]")
 
-      echo $Build.Repository.Name
+      echo $BUILD_REPOSITORY_SHORTNAME
 
-      case "$Build.Repository.Name" in
+      case "$BUILD_REPOSITORY_SHORTNAME" in
           aks-cft-deploy)
               case "$upperCaseEnv" in
                   AAT)

--- a/steps/keyvault-read.yaml
+++ b/steps/keyvault-read.yaml
@@ -21,6 +21,8 @@ steps:
     
       upperCaseEnv=$(echo "${{ parameters.environment }}" | tr "[:lower:]" "[:upper:]")
 
+      $buildRepoSuffix="${{ parameters.buildRepoSuffix }}"
+
       echo $buildRepoSuffix
 
       case "$buildRepoSuffix" in

--- a/steps/keyvault-read.yaml
+++ b/steps/keyvault-read.yaml
@@ -18,9 +18,9 @@ steps:
     scriptLocation: 'inlineScript'
     inlineScript: |
     
-      az account set -s ${{ parameters.serviceConnection }}
-
       upperCaseEnv=$(echo "${{ parameters.environment }}" | tr "[:lower:]" "[:upper:]")
+
+      echo $Build.Repository.Name
 
       case "$Build.Repository.Name" in
           aks-cft-deploy)

--- a/steps/keyvault-read.yaml
+++ b/steps/keyvault-read.yaml
@@ -17,8 +17,17 @@ steps:
     scriptType: 'bash'
     scriptLocation: 'inlineScript'
     inlineScript: |
+    
       az account set -s ${{ parameters.serviceConnection }}
-      SUB_ID=$(az account show --query id -o tsv)
+
+      if [ $Build.Repository.Name == "aks-cft-deploy" ]; then
+        SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-"${{ parameters.environment }}"'].id" -o tsv)
+      elif [ $Build.Repository.Name == "aks-sds-deploy" ]; then
+        SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICES-"${{ parameters.environment }}"'].id" -o tsv)
+      else
+        SUB_ID=$(az account show --query id -o tsv)
+      fi
+
       TENANT_ID=$(az account show --query tenantId -o tsv)
 
       echo $SUB_ID

--- a/steps/keyvault-read.yaml
+++ b/steps/keyvault-read.yaml
@@ -7,6 +7,7 @@ parameters:
   storageAccountVariableName: 'controlStorageAccount'
   keyVaultVariableName: 'controlKeyVault'
   envVariableName: 'env'
+  buildRepoSuffix: ''
 
 steps:
 

--- a/steps/keyvault-read.yaml
+++ b/steps/keyvault-read.yaml
@@ -20,9 +20,9 @@ steps:
     
       upperCaseEnv=$(echo "${{ parameters.environment }}" | tr "[:lower:]" "[:upper:]")
 
-      echo $BUILD_REPOSITORY_SHORTNAME
+      echo $buildRepoSuffix
 
-      case "$BUILD_REPOSITORY_SHORTNAME" in
+      case "$buildRepoSuffix" in
           aks-cft-deploy)
               case "$upperCaseEnv" in
                   AAT)

--- a/steps/keyvault-read.yaml
+++ b/steps/keyvault-read.yaml
@@ -20,15 +20,51 @@ steps:
     
       az account set -s ${{ parameters.serviceConnection }}
 
-      if [ $Build.Repository.Name == "aks-cft-deploy" ]; then
-        SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-"${{ parameters.environment }}"'].id" -o tsv)
-      elif [ $Build.Repository.Name == "aks-sds-deploy" ]; then
-        SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICES-"${{ parameters.environment }}"'].id" -o tsv)
-      else
-        SUB_ID=$(az account show --query id -o tsv)
-      fi
+      upperCaseEnv=$(echo "${{ parameters.environment }}" | tr "[:lower:]" "[:upper:]")
+
+      case "$Build.Repository.Name" in
+          aks-cft-deploy)
+              case "$upperCaseEnv" in
+                  AAT)
+                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-STG'].id" -o tsv)
+                      ;;
+                  PERFTEST)
+                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-TEST'].id" -o tsv)
+                      ;;
+                  PREVIEW)
+                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-DEV'].id" -o tsv)
+                      ;;
+                  PTL)
+                      SUB_ID=$(az account list --query "[?name=='DTS-CFTPTL-INTSVC'].id" -o tsv)
+                      ;;
+                  PTLSBOX)
+                      SUB_ID=$(az account list --query "[?name=='DTS-CFTSBOX-INTSVC'].id" -o tsv)
+                      ;;
+                  *)
+                      SUB_ID=$(az account list --query "[?name=='DCD-CFTAPPS-$upperCaseEnv'].id" -o tsv)
+                      ;;
+              esac
+              ;;
+          aks-sds-deploy)
+              case "$upperCaseEnv" in
+                  PTL)
+                      SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICESPTL'].id" -o tsv)
+                      ;;
+                  PTLSBOX)
+                      SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICESPTL-SBOX'].id" -o tsv)
+                      ;;
+                  *)
+                      SUB_ID=$(az account list --query "[?name=='DTS-SHAREDSERVICES-$upperCaseEnv'].id" -o tsv)
+                      ;;
+              esac
+              ;;
+      esac
 
       TENANT_ID=$(az account show --query tenantId -o tsv)
+
+      SUB_NAME=$(az account list --query "[?id=='$SUB_ID'].name" -o tsv)
+
+      echo $SUB_NAME
 
       echo $SUB_ID
       echo "##vso[task.setvariable variable=${{ parameters.subscriptionIdVariableName }}]$SUB_ID"

--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -82,6 +82,7 @@ steps:
       serviceConnection: ${{ parameters.serviceConnection }}
       environment: ${{ parameters.environment }}
       buildRepoSuffix: $(buildRepoSuffix)
+      component: ${{ parameters.component }}
 
   - task: Bash@3
     displayName: Install tfcmt

--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -81,6 +81,7 @@ steps:
     parameters:
       serviceConnection: ${{ parameters.serviceConnection }}
       environment: ${{ parameters.environment }}
+      buildRepoSuffix: $(buildRepoSuffix)
 
   - task: Bash@3
     displayName: Install tfcmt

--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -82,7 +82,6 @@ steps:
       serviceConnection: ${{ parameters.serviceConnection }}
       environment: ${{ parameters.environment }}
       buildRepoSuffix: $(buildRepoSuffix)
-      component: ${{ parameters.component }}
 
   - task: Bash@3
     displayName: Install tfcmt


### PR DESCRIPTION
### Change description ###
Currently, aks-cft-deploy is storing it's terraform state in sharedservices related storage accounts. As an example, the last modified date on the tfstate for the dts-cftapps-sbox subscription is 25/04/23.

This seems to be down to the keyvault read script returning sharedservices based subscriptions first from `az account show` and computing the storage account name based on said subscription id.

Storing the state in the wrong place isn't the greatest of issues but there are other issues being caused by this downstream such as permissions being granted over cft keyvaults to sds related service principals and managed identities.

[Here](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=392326&view=logs&j=ea2ffe14-2e90-56d6-306f-4291b0be40fb&t=a1ee437a-aef6-50cc-929a-d1e6d9ce954a&l=350) is an example error caused by this phenomenon. This error message is the result of the pipeline using the wrong resource group (it's not from the correct subscription).

I've updated the script to add some logic when running in aks-cft-deploy and aks-sds-deploy so the subscription id, storage account and keyvault are computed correctly.

Alternatively, we could use the CFT specific ops-approval service connections for the cft pipeline i.e. https://github.com/hmcts/aks-cft-deploy/pull/469/files. However, that would only solve this issue for that pipeline. It's not clear yet whether other pipelines have been having the same issue, though most of those using these service connections are PlatOps owned. 

The updated script method would allow us to have a single service connection that would work across a single environment in both cft and sds which I suspect was the original intention.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
