### PR TITLE
change pr cmt target to stage name

### DIFF
--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -194,7 +194,7 @@ steps:
         tfcmt --owner hmcts \
           --repo $(buildRepoSuffix) \
           --pr $(System.PullRequest.PullRequestNumber) \
-          --var target:$(tfPlanName) \
+          --var target:$(System.StageName) \
           --var ado_url:$SYSTEM_COLLECTIONURI \
           --var ado_project:"$SYSTEM_TEAMPROJECT" \
           --var build_id:$BUILD_BUILDID \


### PR DESCRIPTION
The current planname variable is a bit long and has redundant names, gets longer than 50 characters which Github blocks.

https://github.com/hmcts/azure-enterprise-acme/pull/21#issuecomment-1632141000

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
