### PR TITLE
fix: set runAzLogin:true for terraform apply

### DIFF
--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -217,6 +217,7 @@ steps:
       and(succeeded(), eq(variables['isMain'], true), eq(variables['isAutoTriggered'], true))
       )
     inputs:
+      runAzLogin: true
       command: apply
       ${{ if eq( parameters['baseDirectory'], '') }}:
         workingDirectory: '$(System.DefaultWorkingDirectory)/$(buildRepoSuffix)/components/${{ parameters.component }}'


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
add `runAzLogin: true` to terraform apply task to enable local-exec to use the Azure CLI.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
