### PR TITLE
Added trigger for aks manual start which defaults to false

### DIFF
--- a/steps/terraform-precheck.yaml
+++ b/steps/terraform-precheck.yaml
@@ -34,6 +34,10 @@ parameters:
   - name: environment
     default: 'sbox'
 
+  - name: runManualStart
+    type: boolean
+    default: false
+
 steps:
   - checkout: self
   - checkout: cnp-azuredevops-libraries
@@ -68,6 +72,7 @@ steps:
       scriptLocation: 'scriptPath'
       scriptPath: $(System.DefaultWorkingDirectory)/cnp-azuredevops-libraries/scripts/trigger-manual-deploy.sh
       arguments: "$(github-api-token) ${{parameters.projectName}} ${{parameters.environment}} ${{parameters.cluster}}"
+    condition: ${{ eq(parameters.runManualStart, true) }}
 
   - task: PowerShell@2
     displayName: Run PESTER tests


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
Added a trigger that can be set to true on pipelines where we want to run the aks manual start task. Defaults to false

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
