### PR TITLE
Add debug output when terraform init fails

### DIFF
--- a/scripts/ado-terraform-nagger.py
+++ b/scripts/ado-terraform-nagger.py
@@ -666,6 +666,8 @@ def main():
                     )
                 add_error(output_warning, error_message, component, 'failed_init')
 
+                print(output)
+
             ### rerun version --json to fetch providers post init
             command = ["terraform", "version", "--json"]
             result = json.loads(run_command(command, full_path))


### PR DESCRIPTION
Show output when command fails

I had an error here: https://github.com/hmcts/slack-help-bot/pull/357

Where the module was using an SSH connection string which doesn't work if there's no key added to the agent / github