### PR TITLE
Upgrade AzureKeyVault task version (old is deprecated)

### DIFF
--- a/jobs/java-build.yaml
+++ b/jobs/java-build.yaml
@@ -13,7 +13,7 @@ jobs:
   - script: 'env'
     displayName: 'Display Environment Variables'
 
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Get secrets from Keyvault'
     inputs:
       azureSubscription: ${{ parameters.serviceConnection }}

--- a/jobs/launch-aks-agent.yaml
+++ b/jobs/launch-aks-agent.yaml
@@ -9,7 +9,7 @@ jobs:
   steps:
   - checkout: none
 
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Get secrets from Keyvault'
     inputs:
       azureSubscription: ${{ parameters.serviceConnection }}

--- a/steps/bootstrap.yaml
+++ b/steps/bootstrap.yaml
@@ -2,7 +2,7 @@ parameters:
   serviceConnection: ''
 
 steps:
-- task: AzureKeyVault@1
+- task: AzureKeyVault@2
   displayName: 'Get secrets from Keyvault'
   inputs:
     azureSubscription: ${{ parameters.serviceConnection }}

--- a/steps/terraform-precheck.yaml
+++ b/steps/terraform-precheck.yaml
@@ -51,7 +51,7 @@ steps:
       tfswitchArgs: -b ~/.local/bin/terraform --latest
       workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
 
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Retrieve keyvault secret for ADO token'
     inputs:
       ConnectedServiceName: ${{ parameters.serviceConnection }}
@@ -59,7 +59,7 @@ steps:
       secretsFilter: ${{ parameters.keyvaultSecret }}
       runAsPreJob: false
 
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Get GitHub API token from Keyvault'
     inputs:
       runAsPreJob: false

--- a/steps/terraform-version-checker.yaml
+++ b/steps/terraform-version-checker.yaml
@@ -15,7 +15,7 @@ steps:
       git clone https://github.com/hmcts/cnp-deprecation-map.git
     displayName: clone deprecation map
   
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Retrieve slack webhook URL from Keyvault'
     inputs:
       runAsPreJob: false

--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -89,7 +89,7 @@ steps:
       filePath: $(System.DefaultWorkingDirectory)/cnp-azuredevops-libraries/scripts/install-tfcmt.sh
       workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
 
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Get GitHub API token from Keyvault'
     condition: ne(variables['System.PullRequest.PullRequestNumber'], '')
     inputs:


### PR DESCRIPTION
### Change description ###
Noticed in https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=632682&view=results

![image](https://github.com/user-attachments/assets/1f00168b-b415-4150-aa2c-dd859982fe42)

I checked the docs:

https://learn.microsoft.com/en-gb/azure/devops/pipelines/tasks/reference/azure-key-vault-v1?view=azure-pipelines
https://learn.microsoft.com/en-gb/azure/devops/pipelines/tasks/reference/azure-key-vault-v2?view=azure-pipelines

inputs are the same

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
