### PR TITLE
DTSPO-22647 - Update ACR destination

### DIFF
--- a/steps/charts/release.yaml
+++ b/steps/charts/release.yaml
@@ -107,4 +107,4 @@ steps:
       inlineScript: |
         CHART_FILE=$(ls ${{ parameters.chartName }}-[0-9]*.tgz)
         helm repo add hmctspublic https://hmctspublic.azurecr.io/helm/v1/repo || true
-        helm push $CHART_FILE oci://${{ parameters.acrName }}.azurecr.io/helm/${{ parameters.chartName }}
+        helm push $CHART_FILE oci://${{ parameters.acrName }}.azurecr.io/helm/


### PR DESCRIPTION
### Jira link

See [DTSPO-22647](https://tools.hmcts.net/jira/browse/DTSPO-22647)

### Change description

Removing `chartName` from the helm publish command as this creates a structure like `helm/pact-broker/pact-broker`.
Removing it changes the structure to `helm/pact-broker` as an example which means teams can just update the helm repo in flux config without updating the chart reference.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
