### PR TITLE
Improve Pester block descriptions to make it more obvious linting failed

### DIFF
--- a/scripts/terraform-lint.tests.ps1
+++ b/scripts/terraform-lint.tests.ps1
@@ -25,7 +25,7 @@ else
         It "Should not return any linting errors for files in <Instance>" -TestCases $TfFolderTestCases {
           Param($Instance)
           $output = Invoke-Expression "terraform fmt -check=true -diff $Instance"
-          $output | ForEach-Object { Write-Output $_ }
+          $output | ForEach-Object { Write-Host $_ }
           $output | should -BeNullOrEmpty
       }
     }

--- a/scripts/terraform-lint.tests.ps1
+++ b/scripts/terraform-lint.tests.ps1
@@ -22,7 +22,7 @@ else
     $TfFolderTestCases=@()
     ((($TfFiles).DirectoryName | Select-Object -Unique)).ForEach{$TfFolderTestCases += @{Instance = $_}}
       Context "When validated for linting errors" {
-        It "Should not return any linting errors for files in <Instance> directory" -TestCases $TfFolderTestCases {
+        It "Should not return any linting errors for files in <Instance>" -TestCases $TfFolderTestCases {
           Param($Instance)
           $output = Invoke-Expression "terraform fmt -check=true -diff $Instance"
           $output | ForEach-Object { Write-Output $_ }

--- a/scripts/terraform-lint.tests.ps1
+++ b/scripts/terraform-lint.tests.ps1
@@ -7,13 +7,13 @@ if ($TfFiles.Count -eq 0)
 }
 else
 {
-  Describe 'Terraform files validation' {
+  Describe 'Terraform Config' {
     $TfTestCases = @()
     $TfFiles.ForEach{$TfTestCases += @{Instance = $_}}
 
 
-    Context "Check for non zero length files" {
-      It "<Instance> file is greater than 0" -TestCases $TfTestCases {
+    Context "When inspected for empty files" {
+      It "Should contain <Instance> file with length greater than 0" -TestCases $TfTestCases {
         Param($Instance)
         (Get-ChildItem $Instance -Verbose).Length | should -BeGreaterThan 0
       }
@@ -21,10 +21,12 @@ else
 
     $TfFolderTestCases=@()
     ((($TfFiles).DirectoryName | Select-Object -Unique)).ForEach{$TfFolderTestCases += @{Instance = $_}}
-      Context "Are correctly formatted" {
-        It "All files in <Instance> are correctly formatted. By running 'terraform fmt'" -TestCases $TfFolderTestCases {
+      Context "When validated for linting errors" {
+        It "Should not return any linting errors for files in <Instance> directory" -TestCases $TfFolderTestCases {
           Param($Instance)
-          Invoke-Expression "terraform fmt -check=true $Instance"  | should -BeNullOrEmpty
+          $output = Invoke-Expression "terraform fmt -check=true -diff $Instance"
+          $output | ForEach-Object { Write-Output $_ }
+          $output | should -BeNullOrEmpty
       }
     }
   }

--- a/scripts/terraform-lint.tests.ps1
+++ b/scripts/terraform-lint.tests.ps1
@@ -24,9 +24,7 @@ else
       Context "When validated for linting errors" {
         It "Should not return any linting errors for files in <Instance>" -TestCases $TfFolderTestCases {
           Param($Instance)
-          $output = Invoke-Expression "terraform fmt -check=true -diff $Instance"
-          $output | ForEach-Object { Write-Host $_ }
-          $output | should -BeNullOrEmpty
+          Invoke-Expression "terraform fmt -check=true $Instance" | should -BeNullOrEmpty -Because "all files should pass linting"
       }
     }
   }


### PR DESCRIPTION
### Jira link

N/A

### Change description

Proposing small change to the Pester lint test descritpions in pre-check step

- Amend Pester block descriptions so that they read better as a sentence in BDD style so that the failed output is easier to understand
- Add "because" parameter to further improve readability

### Testing done

I took this branch and run it in my lab pipeline with linting violations added to ensure changes are doing what I expect.
I also run updated script in local powershell

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] (N/A) README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
