### PR TITLE
Lower tfswitch version to 1.3.0 as 1.4.0 doesn't seem to switch the version at all

### DIFF
--- a/steps/install-use-tfswitch.yaml
+++ b/steps/install-use-tfswitch.yaml
@@ -5,7 +5,7 @@ parameters:
   - name: tfswitchArgs
     default: ''
   - name: tfswitchVersion
-    default: '1.3.0'
+    default: 'v1.3.0'
   - name: tfswitchPath
     default: '~/.local/bin'
 steps:

--- a/steps/install-use-tfswitch.yaml
+++ b/steps/install-use-tfswitch.yaml
@@ -5,7 +5,7 @@ parameters:
   - name: tfswitchArgs
     default: ''
   - name: tfswitchVersion
-    default: 'latest'
+    default: '1.3.0'
   - name: tfswitchPath
     default: '~/.local/bin'
 steps:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24542

### Change description
Latest TF-Switch 1.4.0 doesn't seem to be switching the terraform to specified version at all which causes pipelines to fail due to incorrect version.
I have also seen it flip-flop between versions randomly adding more chaos to it all.

### Testing done
Failure: https://github.com/hmcts/crime-portal-infra/pull/74
Fixed using this branch: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=767877&view=logs&j=8968f343-168c-5476-0fb0-a5b9d1a0ae81&t=8968f343-168c-5476-0fb0-a5b9d1a0ae81

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
