### PR TITLE
[DTSPO-28054] Improve readability of nagger warnings in ADO

### DIFF
--- a/steps/terraform-version-checker.yaml
+++ b/steps/terraform-version-checker.yaml
@@ -12,7 +12,7 @@ steps:
   - template: ./set-build-repo-suffix-env-var.yaml
 
   - script: |
-      git clone -b DTSPO-28054 https://github.com/hmcts/cnp-deprecation-map.git
+      git clone https://github.com/hmcts/cnp-deprecation-map.git
     displayName: clone deprecation map
   
   - task: AzureKeyVault@2


### PR DESCRIPTION
### Jira link
[DTSPO-28054](https://tools.hmcts.net/jira/browse/DTSPO-28054
)
### Change description
Updated nagger log messages to include more information on which version is expected.

### Testing done
Version lower than expected, deadline not passed:
https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=956445&view=results
<img width="1746" height="148" alt="image" src="https://github.com/user-attachments/assets/b4c8bb64-05f1-4f1f-90b1-bd000479acf9" />

Version lower than expected, deadline passed:
https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=956454&view=results
<img width="1852" height="92" alt="image" src="https://github.com/user-attachments/assets/cd9d70f4-7874-4fe2-86d8-64954a9a9c5a" />

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
