### PR TITLE
Swap cluster check from /health to /health/liveness

### DIFF
--- a/scripts/trigger-manual-deploy.sh
+++ b/scripts/trigger-manual-deploy.sh
@@ -102,7 +102,7 @@ function check_environment_health() {
   environment="$2"
   project_url="plum" && [[ "${project}" == "SDS" ]] && project_url="toffee"
   env="sandbox" && [[ "${environment}" != "sbox" ]] && env=$environment
-  TEST_URL="https://${project_url}.${env}.platform.hmcts.net/health"
+  TEST_URL="https://${project_url}.${env}.platform.hmcts.net/health/liveness"
 
   MAX_ATTEMPTS=5
   SLEEP_TIME=3


### PR DESCRIPTION
### Change description

- Swap the cluster check which relies on plum frontend to fetch /health/liveness instead of /health
- /health endpoint returns error code if backend has a problem also
- By using /health/liveness this constrains the check to only if plum-frontend is up
- This will allow us to continue TLS E2E POC using plum-recipe-service for testing APIM flow with TLS without interupting pipelines that rely on this check

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
