### PR TITLE
Revert "Swap cluster check from /health to /health/liveness"

### DIFF
--- a/scripts/trigger-manual-deploy.sh
+++ b/scripts/trigger-manual-deploy.sh
@@ -102,7 +102,7 @@ function check_environment_health() {
   environment="$2"
   project_url="plum" && [[ "${project}" == "SDS" ]] && project_url="toffee"
   env="sandbox" && [[ "${environment}" != "sbox" ]] && env=$environment
-  TEST_URL="https://${project_url}.${env}.platform.hmcts.net/health/liveness"
+  TEST_URL="https://${project_url}.${env}.platform.hmcts.net/health"
 
   MAX_ATTEMPTS=5
   SLEEP_TIME=3


### PR DESCRIPTION
Reverts hmcts/cnp-azuredevops-libraries#239

- pipeline tests still rely on /health endpoint and dont want to change them. Will rollback plum-recipe-backend changes instead and deploy a second instance