### PR TITLE
We need to add a check for overrideAction: 'apply' to the automatic d…

### DIFF
--- a/steps/terraform.yaml
+++ b/steps/terraform.yaml
@@ -255,7 +255,7 @@ steps:
     condition: |
       or(
       and(succeeded(), eq('${{ parameters.overrideAction }}', 'apply')),
-      and(succeeded(), eq(variables['isMain'], true), eq(variables['isAutoTriggered'], true))
+      and(succeeded(), eq(variables['isMain'], true), eq(variables['isAutoTriggered'], true), eq('${{ parameters.overrideAction }}', 'apply'))
       )
     inputs:
       runAzLogin: true


### PR DESCRIPTION
…eployment block to ensure that automated merges only deploy if the action parameter explicitly requested it.

### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [WM-515](https://tools.hmcts.net/jira/browse/WM-515)

### Change description
The Terraform apply task in steps/terraform.yaml has a condition designed to run the deployment if it detects a highly trusted, automatic build context. This logic overrides the explicit action parameter we pass:
Code Location - The Terraform apply task within steps/terraform.yaml.
Problem Condition - The apply task executes if EITHER of the following is true:
overrideAction is explicitly 'apply'.
The system variables are set to: eq(variables['isMain'], true) AND eq(variables['isAutoTriggered'], true).
Our automatic Continuous Integration (CI) build, which runs when code is merged to main, sets these system variables to true. Because the original condition did not check that overrideAction was also set to 'apply', it triggered the deployment even though our pipeline specified overrideAction: plan.
The pipeline logic was: "If it's an auto-trigger on main, deploy, regardless of the requested action."
The fix must be implemented in the cnp-azuredevops-libraries repository by modifying the Terraform apply task condition in steps/terraform.yaml.
We need to add a check for overrideAction: 'apply' to the automatic deployment block to ensure that automated merges only deploy if the action parameter explicitly requested it.
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
