### PR TITLE
DTSPO-28859: fix helm tests due to azurepolicy-k8sazurev1blocknakedpods policy block

### DIFF
--- a/steps/charts/validate.yaml
+++ b/steps/charts/validate.yaml
@@ -105,7 +105,48 @@ steps:
       workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
       displayName: "Wait for chart resources to be provisioned"
 
-    - script: helm test --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} --logs --timeout ${{ parameters.helmTestTimeout }}s
+    - script: |
+        # Run helm test without --logs (doesn't work with Job-based tests)
+        helm test --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} --timeout ${{ parameters.helmTestTimeout }}s
+        
+        # Get logs from test resources
+        echo ""
+        echo "==================== Test Logs ===================="
+        
+        # Find test jobs created by this release (first try by label)
+        TEST_JOBS=$(kubectl get jobs -n ${{ parameters.chartNamespace }} \
+          -l "app.kubernetes.io/instance=${{ parameters.chartReleaseName }}" \
+          -o json | jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | .metadata.name')
+        
+        if [ -z "$TEST_JOBS" ]; then
+          # Fallback: search by name prefix if labels aren't present
+          TEST_JOBS=$(kubectl get jobs -n ${{ parameters.chartNamespace }} -o json | \
+            jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | select(.metadata.name | startswith("${{ parameters.chartReleaseName }}")) | .metadata.name')
+        fi
+        
+        if [ -n "$TEST_JOBS" ]; then
+          # Job-based tests
+          for job in $TEST_JOBS; do
+            echo "--- Logs from job: $job ---"
+            kubectl logs -n ${{ parameters.chartNamespace }} -l "job-name=$job" --tail=-1 --ignore-errors=true
+          done
+        else
+          # Pod-based tests (legacy or no jobs found)
+          TEST_PODS=$(kubectl get pods -n ${{ parameters.chartNamespace }} \
+            -l "app.kubernetes.io/instance=${{ parameters.chartReleaseName }}" \
+            -o json | jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | .metadata.name')
+          
+          if [ -n "$TEST_PODS" ]; then
+            for pod in $TEST_PODS; do
+              echo "--- Logs from pod: $pod ---"
+              kubectl logs -n ${{ parameters.chartNamespace }} $pod --ignore-errors=true
+            done
+          else
+            echo "No test jobs or pods found for release ${{ parameters.chartReleaseName }}"
+          fi
+        fi
+        
+        echo "==================================================="
       workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
       displayName: "Helm Test"
 
@@ -141,7 +182,49 @@ steps:
     - script: sleep ${{ parameters.helmInstallWait }}
       displayName: "Wait for chart resources to be provisioned"
 
-    - script: helm test --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} --logs --timeout ${{ parameters.helmTestTimeout }}s
+    - script: |
+        # Run helm test without --logs (doesn't work with Job-based tests)
+        helm test --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} --timeout ${{ parameters.helmTestTimeout }}s
+        
+        # Get logs from test resources
+        echo ""
+        echo "==================== Test Logs ===================="
+        
+        # Find test jobs created by this release (first try by label)
+        TEST_JOBS=$(kubectl get jobs -n ${{ parameters.chartNamespace }} \
+          -l "app.kubernetes.io/instance=${{ parameters.chartReleaseName }}" \
+          -o json | jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | .metadata.name')
+        
+        if [ -z "$TEST_JOBS" ]; then
+          # Fallback: search by name prefix if labels aren't present
+          TEST_JOBS=$(kubectl get jobs -n ${{ parameters.chartNamespace }} -o json | \
+            jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | select(.metadata.name | startswith("${{ parameters.chartReleaseName }}")) | .metadata.name')
+        fi
+        
+        if [ -n "$TEST_JOBS" ]; then
+          # Job-based tests
+          for job in $TEST_JOBS; do
+            echo "--- Logs from job: $job ---"
+            kubectl logs -n ${{ parameters.chartNamespace }} -l "job-name=$job" --tail=-1 --ignore-errors=true
+          done
+        else
+          # Pod-based tests (legacy or no jobs found)
+          TEST_PODS=$(kubectl get pods -n ${{ parameters.chartNamespace }} \
+            -l "app.kubernetes.io/instance=${{ parameters.chartReleaseName }}" \
+            -o json | jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | .metadata.name')
+          
+          if [ -n "$TEST_PODS" ]; then
+            for pod in $TEST_PODS; do
+              echo "--- Logs from pod: $pod ---"
+              kubectl logs -n ${{ parameters.chartNamespace }} $pod --ignore-errors=true
+            done
+          else
+            echo "No test jobs or pods found for release ${{ parameters.chartReleaseName }}"
+          fi
+        fi
+        
+        echo "==================================================="
+      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
       displayName: "Helm Test"
 
     - script: helm delete --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-28859


### Change description

- azurepolicy-k8sazurev1blocknakedpods is blocking neuvector helm tests in the sandbox environment
- policy states no 'naked' pods are allowed (no pods without ownership) which is what helm test wants to create
- workaround for this is to spawn the pod via a Job, which has been implemented in chart-neuvector repo
- Code update ensures test works for both Pod & Job, --logs switch cannot be used for Job as the child Pod which it spawns is always suffixed with a -<random> string so switch cannot find the Pod to get logs from
- Instead, for Job the switch is removed and child Pod name is determined logically to recieve logs in a follow-omn command

### Testing done

- Works fine for [chart-neuvector using a Job](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=992433&view=logs&j=92058b04-f16a-5035-546c-cae3ad5e2f5f&t=a7e8c8f9-0789-5559-aa94-3633730a4214)
- Fallback is same as previous code for Pod

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
