### PR TITLE
Pin tfswitch version

### DIFF
--- a/steps/install-use-tfswitch.yaml
+++ b/steps/install-use-tfswitch.yaml
@@ -5,7 +5,7 @@ parameters:
   - name: tfswitchArgs
     default: ''
   - name: tfswitchVersion
-    default: 'latest'
+    default: 'v1.16.0'
   - name: tfswitchPath
     default: '~/.local/bin'
 steps:


### PR DESCRIPTION
### Change description

Better to pin version for security reasons in case there is a supply chain side attack upstream
Same version that is currently being used by latest
Testing in https://github.com/hmcts/shared-datagateway-terraform/pull/55

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
