### PR TITLE
Updating chart validation template, adding readme for guidance

### DIFF
--- a/steps/charts/README.md
+++ b/steps/charts/README.md
@@ -1,0 +1,97 @@
+# Chart Validation Template
+
+`steps/charts/validate.yaml` — Azure DevOps step template for Helm chart CI validation against a live AKS cluster.
+
+## What it does
+
+1. Authenticates to AKS and ACR
+2. Resolves the chart path
+3. Manages namespace lifecycle (create / reuse / label)
+4. Optionally deletes a pre-existing Helm release before install
+5. Runs `helm lint`, `helm install`, `helm test` (with log capture)
+6. Cleans up the Helm release and namespace on success
+
+## Usage
+
+```yaml
+steps:
+  - template: steps/charts/validate.yaml@cnp-azuredevops-libraries
+    parameters:
+      chartName: my-chart
+      chartReleaseName: my-chart-ci
+      chartNamespace: my-chart-ci
+      createNamespace: true
+      valuesFile: ci-values.yaml
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `serviceConnection` | `DCD-CFTAPPS-DEV` | Azure service connection for AKS auth |
+| `registryServiceConnection` | `azurerm-prod` | Azure service connection for ACR login |
+| `acrName` | `hmctsprod` | ACR instance to authenticate against |
+| `chartName` | _(required)_ | Chart directory name (relative to `chartPath`) |
+| `chartReleaseName` | _(required)_ | Helm release name used for install/test/delete |
+| `chartNamespace` | _(required)_ | Kubernetes namespace for the release |
+| `chartPath` | `./` | Path to the chart root; combined with `chartName` when not `./` |
+| `createNamespace` | `false` | When `true`, enables namespace lifecycle management and post-test cleanup |
+| `helmVersion` | `3.17.1` | Helm version to install |
+| `helmInstallTimeout` | `120` | Seconds to wait for `helm install` |
+| `helmTestTimeout` | `300` | Seconds to wait for `helm test` |
+| `helmDeleteWait` | `0` | Seconds to wait after pre-install helm delete |
+| `helmInstallWait` | `0` | Seconds to wait after helm install before testing |
+| `valuesFile` | `ci-values.yaml` | Values file passed to `helm install` |
+| `additionalHelmArgs` | _(empty)_ | Extra args appended to `helm install` |
+| `aksResourceGroup` | _(empty)_ | Override AKS resource group (skips auto-detect) |
+| `aksCluster` | _(empty)_ | Override AKS cluster name (skips auto-detect) |
+| `clustersToCheck` | cft-preview-00/01 | List of clusters to probe for active cluster auto-detection |
+
+## Namespace lifecycle (`createNamespace`)
+
+### `createNamespace: false` (default)
+
+No namespace management. Template assumes the namespace exists. Pre-install helm delete runs to clear any stale release.
+
+### `createNamespace: true`
+
+The template inspects the namespace at runtime and sets three pipeline variables:
+
+| Variable | Values | Meaning |
+|---|---|---|
+| `namespaceCreatedByPipeline` | `true` / `false` | Pipeline created the namespace in this run |
+| `namespaceManagedByPipeline` | `true` / `false` | Namespace carries the `cnp.validate/template=true` label from a prior run |
+| `deletePreviousRelease` | `true` / `false` | Whether to delete any existing Helm release before install |
+
+### Scenario outcomes
+
+| Scenario | Pre-install helm delete | Post-test helm delete | Namespace delete |
+|---|---|---|---|
+| `createNamespace=false` | Yes | No | No |
+| `createNamespace=true` — namespace **does not exist** | No | Yes | Yes |
+| `createNamespace=true` — namespace exists, **pipeline-managed** (label present) | Yes | Yes | No¹ |
+| `createNamespace=true` — namespace exists, **unmanaged** (no label) | Yes | Yes | No |
+
+> ¹ Namespace was created by a _previous_ pipeline run (label present, but `namespaceCreatedByPipeline=false` for this run). The pipeline leaves it in place.
+
+**Rule of thumb:** the namespace is only deleted when _this run_ created it **and** the pipeline succeeded. If this run created the namespace but the pipeline failed, the namespace is left intact for debugging. The Helm release is always cleaned up when `createNamespace=true`.
+
+## Namespace labels
+
+When the pipeline creates a namespace it applies:
+
+```
+cnp.validate/template=true
+cnp.validate/build-id=<Build.BuildId>
+```
+
+Labels are applied **only at creation time**. Reusing an existing namespace (managed or unmanaged) never relabels it. The `cnp.validate/template=true` label is how the pipeline identifies namespaces it owns across runs.
+
+## Chart path resolution
+
+| `chartPath` | `chartName` | Resolved target |
+|---|---|---|
+| `./` | `my-chart` | `my-chart` |
+| `helm/` | `my-chart` | `helm/my-chart` |
+| `helm/` | `/my-chart` | `helm/my-chart` (leading `/` stripped) |
+| `helm` | `my-chart` | `helm/my-chart` (trailing `/` added) |

--- a/steps/charts/validate.yaml
+++ b/steps/charts/validate.yaml
@@ -6,6 +6,7 @@ parameters:
   chartReleaseName: ""
   chartNamespace: ""
   chartPath: "./"
+  createNamespace: false
   helmVersion: "3.17.1"
   helmInstallTimeout: "120"
   helmTestTimeout: "300"
@@ -24,7 +25,7 @@ parameters:
       aksEnvironment: preview
 
 steps:
-  
+
   - checkout: self
     clean: true
 
@@ -69,163 +70,146 @@ steps:
       workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
       inlineScript: |
         export HELM_EXPERIMENTAL_OCI=1
-        az acr login --name ${{parameters.acrName}} 
+        az acr login --name ${{parameters.acrName}}
 
-  - ${{ if eq(parameters.chartPath, './') }}:
-    - script: |
-        echo "Chart Path: ${{ parameters.chartPath }}"
-        echo "Working Dir: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)"
-        ls -l
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
-      displayName: "Provide useful information"
+  - script: |
+      if [ "${{ parameters.chartPath }}" = "./" ]; then
+        CHART_TARGET="${{ parameters.chartName }}"
+      else
+        CHART_PATH_TRIMMED="${{ parameters.chartPath }}"
+        CHART_PATH_TRIMMED="${CHART_PATH_TRIMMED%/}"
+        CHART_NAME_TRIMMED="${{ parameters.chartName }}"
+        CHART_NAME_TRIMMED="${CHART_NAME_TRIMMED#/}"
+        CHART_TARGET="${CHART_PATH_TRIMMED}/${CHART_NAME_TRIMMED}"
+      fi
 
-    - script: helm dependency update ${{ parameters.chartName }}
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
-      displayName: "Retrieve helm dependencies (if any)"
+      echo "Resolved chart target: ${CHART_TARGET}"
+      echo "##vso[task.setvariable variable=chartTarget]${CHART_TARGET}"
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Resolve chart target and namespace options"
 
-    - script: helm delete --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} || true
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
-      displayName: "Delete Previous Test Chart"
+  - script: |
+      echo "Chart Path: ${{ parameters.chartPath }}"
+      echo "Chart Target: $(chartTarget)"
+      echo "Working Dir: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)"
+      ls -l
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Provide useful information"
 
-    - script: sleep ${{ parameters.helmDeleteWait }}
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
-      displayName: "Wait for previous chart resources to be deprovisioned"
+  - script: |
+      if [ "${{ parameters.createNamespace }}" != "true" ]; then
+        echo "Namespace creation disabled for this run."
+        echo "##vso[task.setvariable variable=namespaceCreatedByPipeline]false"
+        echo "##vso[task.setvariable variable=namespaceManagedByPipeline]false"
+        echo "##vso[task.setvariable variable=deletePreviousRelease]true"
+        exit 0
+      fi
 
-    - script: |
-        ls -Rla ${{ parameters.chartName }}
-        helm lint ${{ parameters.chartName }}
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
-      displayName: "Helm Lint"
+      if kubectl get namespace ${{ parameters.chartNamespace }} >/dev/null 2>&1; then
+        echo "Namespace ${{ parameters.chartNamespace }} already exists."
+        PIPELINE_LABEL=$(kubectl get namespace ${{ parameters.chartNamespace }} -o jsonpath='{.metadata.labels.cnp\.validate/template}' 2>/dev/null || true)
+        echo "##vso[task.setvariable variable=namespaceCreatedByPipeline]false"
+        if [ "$PIPELINE_LABEL" = "true" ]; then
+          echo "Namespace ${{ parameters.chartNamespace }} is managed by validation pipeline."
+          echo "##vso[task.setvariable variable=namespaceManagedByPipeline]true"
+          echo "##vso[task.setvariable variable=deletePreviousRelease]true"
+        else
+          echo "Namespace ${{ parameters.chartNamespace }} is not pipeline-managed. Reusing namespace, will clean up helm release only."
+          echo "##vso[task.setvariable variable=namespaceManagedByPipeline]false"
+          echo "##vso[task.setvariable variable=deletePreviousRelease]true"
+        fi
+      else
+        echo "Creating namespace ${{ parameters.chartNamespace }} for validation run."
+        kubectl create namespace ${{ parameters.chartNamespace }}
+        kubectl label namespace ${{ parameters.chartNamespace }} cnp.validate/template=true cnp.validate/build-id=$(Build.BuildId) --overwrite
+        echo "##vso[task.setvariable variable=namespaceCreatedByPipeline]true"
+        echo "##vso[task.setvariable variable=namespaceManagedByPipeline]true"
+        echo "##vso[task.setvariable variable=deletePreviousRelease]false"
+      fi
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Create namespace for validation"
 
-    - script: helm install ${{ parameters.chartReleaseName }} ${{ parameters.chartName }} --namespace ${{ parameters.chartNamespace }} -f ${{ parameters.valuesFile }} --wait --timeout ${{ parameters.helmInstallTimeout }}s ${{ parameters.additionalHelmArgs }}
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
-      displayName: "Helm Install"
+  - script: helm delete --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} || true
+    condition: eq(variables['deletePreviousRelease'], 'true')
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Delete Previous Test Chart"
 
-    - script: sleep ${{ parameters.helmInstallWait }}
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
-      displayName: "Wait for chart resources to be provisioned"
+  - script: sleep ${{ parameters.helmDeleteWait }}
+    condition: eq(variables['deletePreviousRelease'], 'true')
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Wait for previous chart resources to be deprovisioned"
 
-    - script: |
-        # Run helm test without --logs (doesn't work with Job-based tests)
-        helm test --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} --timeout ${{ parameters.helmTestTimeout }}s
-        
-        # Get logs from test resources
-        echo ""
-        echo "==================== Test Logs ===================="
-        
-        # Find test jobs created by this release (first try by label)
-        TEST_JOBS=$(kubectl get jobs -n ${{ parameters.chartNamespace }} \
+  - script: helm dependency update $(chartTarget)
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Retrieve helm dependencies (if any)"
+
+  - script: |
+      ls -Rla $(chartTarget)
+      helm lint $(chartTarget)
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Helm Lint"
+
+  - script: helm install ${{ parameters.chartReleaseName }} $(chartTarget) --namespace ${{ parameters.chartNamespace }} -f ${{ parameters.valuesFile }} --wait --timeout ${{ parameters.helmInstallTimeout }}s ${{ parameters.additionalHelmArgs }}
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Helm Install"
+
+  - script: sleep ${{ parameters.helmInstallWait }}
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Wait for chart resources to be provisioned"
+
+  - script: |
+      # Run helm test without --logs (doesn't work with Job-based tests)
+      helm test --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} --timeout ${{ parameters.helmTestTimeout }}s
+
+      # Get logs from test resources
+      echo ""
+      echo "==================== Test Logs ===================="
+
+      # Find test jobs created by this release (first try by label)
+      TEST_JOBS=$(kubectl get jobs -n ${{ parameters.chartNamespace }} \
+        -l "app.kubernetes.io/instance=${{ parameters.chartReleaseName }}" \
+        -o json | jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | .metadata.name')
+
+      if [ -z "$TEST_JOBS" ]; then
+        # Fallback: search by name prefix if labels aren't present
+        TEST_JOBS=$(kubectl get jobs -n ${{ parameters.chartNamespace }} -o json | \
+          jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | select(.metadata.name | startswith("${{ parameters.chartReleaseName }}")) | .metadata.name')
+      fi
+
+      if [ -n "$TEST_JOBS" ]; then
+        # Job-based tests
+        for job in $TEST_JOBS; do
+          echo "--- Logs from job: $job ---"
+          kubectl logs -n ${{ parameters.chartNamespace }} -l "job-name=$job" --tail=-1 --ignore-errors=true
+        done
+      else
+        # Pod-based tests (legacy or no jobs found)
+        TEST_PODS=$(kubectl get pods -n ${{ parameters.chartNamespace }} \
           -l "app.kubernetes.io/instance=${{ parameters.chartReleaseName }}" \
           -o json | jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | .metadata.name')
-        
-        if [ -z "$TEST_JOBS" ]; then
-          # Fallback: search by name prefix if labels aren't present
-          TEST_JOBS=$(kubectl get jobs -n ${{ parameters.chartNamespace }} -o json | \
-            jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | select(.metadata.name | startswith("${{ parameters.chartReleaseName }}")) | .metadata.name')
-        fi
-        
-        if [ -n "$TEST_JOBS" ]; then
-          # Job-based tests
-          for job in $TEST_JOBS; do
-            echo "--- Logs from job: $job ---"
-            kubectl logs -n ${{ parameters.chartNamespace }} -l "job-name=$job" --tail=-1 --ignore-errors=true
+
+        if [ -n "$TEST_PODS" ]; then
+          for pod in $TEST_PODS; do
+            echo "--- Logs from pod: $pod ---"
+            kubectl logs -n ${{ parameters.chartNamespace }} $pod --ignore-errors=true
           done
         else
-          # Pod-based tests (legacy or no jobs found)
-          TEST_PODS=$(kubectl get pods -n ${{ parameters.chartNamespace }} \
-            -l "app.kubernetes.io/instance=${{ parameters.chartReleaseName }}" \
-            -o json | jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | .metadata.name')
-          
-          if [ -n "$TEST_PODS" ]; then
-            for pod in $TEST_PODS; do
-              echo "--- Logs from pod: $pod ---"
-              kubectl logs -n ${{ parameters.chartNamespace }} $pod --ignore-errors=true
-            done
-          else
-            echo "No test jobs or pods found for release ${{ parameters.chartReleaseName }}"
-          fi
+          echo "No test jobs or pods found for release ${{ parameters.chartReleaseName }}"
         fi
-        
-        echo "==================================================="
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
-      displayName: "Helm Test"
+      fi
 
-    - script: helm delete --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }}
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
-      displayName: "Delete test Chart"
+      echo "==================================================="
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Helm Test"
 
-  - ${{ else }}:
+  - script: helm delete --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} || true
+    condition: and(succeeded(), eq('${{ parameters.createNamespace }}', 'true'))
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Delete test Chart"
 
-    - script: |
-        echo "Chart Path: ${{ parameters.chartPath }}"
-        echo "Working Dir: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)"
-        ls -l
-      displayName: "Provide useful information"
-
-    - script: helm dependency update ${{ parameters.chartPath }}${{ parameters.chartName }}
-      displayName: "Retrieve helm dependencies (if any)"
-
-    - script: helm delete --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} || true
-      displayName: "Delete Previous Test Chart"
-
-    - script: sleep ${{ parameters.helmDeleteWait }}
-      displayName: "Wait for previous chart resources to be deprovisioned"
-
-    - script: |
-        ls -Rla ${{ parameters.chartPath }}${{ parameters.chartName }}
-        helm lint ${{ parameters.chartPath }}${{ parameters.chartName }}
-      displayName: "Helm Lint"
-
-    - script: helm install ${{ parameters.chartReleaseName }} ${{ parameters.chartPath }}${{ parameters.chartName }} --namespace ${{ parameters.chartNamespace }} -f ${{ parameters.valuesFile }} --wait --timeout ${{ parameters.helmInstallTimeout }}s ${{ parameters.additionalHelmArgs }}
-      displayName: "Helm Install"
-
-    - script: sleep ${{ parameters.helmInstallWait }}
-      displayName: "Wait for chart resources to be provisioned"
-
-    - script: |
-        # Run helm test without --logs (doesn't work with Job-based tests)
-        helm test --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }} --timeout ${{ parameters.helmTestTimeout }}s
-        
-        # Get logs from test resources
-        echo ""
-        echo "==================== Test Logs ===================="
-        
-        # Find test jobs created by this release (first try by label)
-        TEST_JOBS=$(kubectl get jobs -n ${{ parameters.chartNamespace }} \
-          -l "app.kubernetes.io/instance=${{ parameters.chartReleaseName }}" \
-          -o json | jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | .metadata.name')
-        
-        if [ -z "$TEST_JOBS" ]; then
-          # Fallback: search by name prefix if labels aren't present
-          TEST_JOBS=$(kubectl get jobs -n ${{ parameters.chartNamespace }} -o json | \
-            jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | select(.metadata.name | startswith("${{ parameters.chartReleaseName }}")) | .metadata.name')
-        fi
-        
-        if [ -n "$TEST_JOBS" ]; then
-          # Job-based tests
-          for job in $TEST_JOBS; do
-            echo "--- Logs from job: $job ---"
-            kubectl logs -n ${{ parameters.chartNamespace }} -l "job-name=$job" --tail=-1 --ignore-errors=true
-          done
-        else
-          # Pod-based tests (legacy or no jobs found)
-          TEST_PODS=$(kubectl get pods -n ${{ parameters.chartNamespace }} \
-            -l "app.kubernetes.io/instance=${{ parameters.chartReleaseName }}" \
-            -o json | jq -r '.items[] | select(.metadata.annotations."helm.sh/hook" == "test") | .metadata.name')
-          
-          if [ -n "$TEST_PODS" ]; then
-            for pod in $TEST_PODS; do
-              echo "--- Logs from pod: $pod ---"
-              kubectl logs -n ${{ parameters.chartNamespace }} $pod --ignore-errors=true
-            done
-          else
-            echo "No test jobs or pods found for release ${{ parameters.chartReleaseName }}"
-          fi
-        fi
-        
-        echo "==================================================="
-      workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
-      displayName: "Helm Test"
-
-    - script: helm delete --namespace ${{ parameters.chartNamespace }} ${{ parameters.chartReleaseName }}
-      displayName: "Delete test Chart"
+  - script: |
+      echo "Deleting namespace ${{ parameters.chartNamespace }} created by this validation run."
+      kubectl delete namespace ${{ parameters.chartNamespace }}
+    condition: and(succeeded(), eq('${{ parameters.createNamespace }}', 'true'), eq(variables['namespaceCreatedByPipeline'], 'true'))
+    workingDirectory: $(System.DefaultWorkingDirectory)/$(buildRepoSuffix)
+    displayName: "Delete validation namespace"


### PR DESCRIPTION
### Change description
Updating validation template to:
- Reduce code duplication
- Add namespace creation option, ephemeral namespace to be used for clean install/validation/testing of standalone charts e.g. Neuvector.
- cleanup of namespaces created only by the pipeline
- failures retain namespace and re-used until successful testing completed
- Ensure logic applies for existing namespaces and old test runs cleaned up in these instances

Adding readme for validation template with details on namespace usage and scenarios

### Testing done
Tested:
with namespace creation (pipeline failed due to other errors unrelated to script changes)
https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=1095672&view=logs&j=92058b04-f16a-5035-546c-cae3ad5e2f5f&t=b67ccd6a-d073-548d-7064-f673a2522e2b

without namespace creation: successfully skipped namespace creation
https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=1095697&view=logs&j=b54c42c5-88bc-5481-8742-be4e715c5d16&t=7cb58ecf-1186-54e0-7a3d-ca1761e331ee&s=d654deb9-056d-50a2-1717-90c08683d50a