### PR TITLE
Add quotes to pester version

### DIFF
--- a/scripts/pester-tests.ps1
+++ b/scripts/pester-tests.ps1
@@ -1,4 +1,4 @@
-$PESTER_VERSION=5.5.0
+$PESTER_VERSION="5.5.0"
 
 if (-Not (Get-Module -ListAvailable -Name Pester)) {
   Install-Module -Name Pester -MaximumVersion $PESTER_VERSION -Force -Verbose -Scope CurrentUser


### PR DESCRIPTION
### Change description

Without the quotes, the latest version gets pulled which has breaking changes:

```
/usr/bin/pwsh -NoLogo -NoProfile -NonInteractive -Command . '/azp/_work/_temp/e1e35cd6-a694-441d-ba27-c7527a326a6b.ps1'
VERBOSE: Acquiring providers for assembly: /opt/microsoft/powershell/7/Modules/PackageManagement/coreclr/netstandard2.0/Microsoft.PackageManagement.ArchiverProviders.dll
VERBOSE: Acquiring providers for assembly: /opt/microsoft/powershell/7/Modules/PackageManagement/coreclr/netstandard2.0/Microsoft.PackageManagement.NuGetProvider.dll
VERBOSE: Acquiring providers for assembly: /opt/microsoft/powershell/7/Modules/PackageManagement/coreclr/netstandard2.0/Microsoft.PackageManagement.MetaProvider.PowerShell.dll
VERBOSE: Acquiring providers for assembly: /opt/microsoft/powershell/7/Modules/PackageManagement/coreclr/netstandard2.0/Microsoft.PackageManagement.CoreProviders.dll
VERBOSE: Using the provider 'PowerShellGet' for searching packages.
VERBOSE: The -Repository parameter was not specified.  PowerShellGet will use all of the registered repositories.
VERBOSE: Getting the provider object for the PackageManagement Provider 'NuGet'.
VERBOSE: The specified Location is 'https://www.powershellgallery.com/api/v2' and PackageManagementProvider is 'NuGet'.
VERBOSE: Searching repository '[https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Pester''](https://www.powershellgallery.com/api/v2/FindPackagesById()?id=%27Pester%27%27) for ''.
VERBOSE: Total package yield:'1' for the specified package 'Pester'.
VERBOSE: Performing the operation "Install-Module" on target "Version '6.0.0' of module 'Pester'".
VERBOSE: The installation scope is specified to be 'CurrentUser'.
VERBOSE: The specified module will be installed in '/root/.local/share/powershell/Modules'.
VERBOSE: The specified Location is 'NuGet' and PackageManagementProvider is 'NuGet'.
VERBOSE: Downloading module 'Pester' with version '6.0.0' from the repository 'https://www.powershellgallery.com/api/v2'.
VERBOSE: Searching repository '[https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Pester''](https://www.powershellgallery.com/api/v2/FindPackagesById()?id=%27Pester%27%27) for ''.
VERBOSE: InstallPackage' - name='Pester', version='6.0.0',destination='/tmp/1753366543'
VERBOSE: DownloadPackage' - name='Pester', version='6.0.0',destination='/tmp/1753366543/Pester.6.0.0/Pester.6.0.0.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Pester/6.0.0'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Pester/6.0.0'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Pester/6.0.0'.
VERBOSE: Completed downloading 'Pester'.
VERBOSE: InstallPackageLocal' - name='Pester', version='6.0.0',destination='/tmp/1753366543'
VERBOSE: Validating the 'Pester' module contents under '/tmp/1753366543/Pester.6.0.0' path.
VERBOSE: Test-ModuleManifest successfully validated the module manifest file '/tmp/1753366543/Pester.6.0.0'.
VERBOSE: Module 'Pester' was installed successfully to path '/root/.local/share/powershell/Modules/Pester/6.0.0'.
Invoke-Pester: /azp/_work/1/s/cnp-azuredevops-libraries/scripts/pester-tests.ps1:6
Line |
   6 |  Invoke-Pester ../ -OutputFormat NUnitXml -OutputFile ./TEST-CI.xml -E …
     |                    ~~~~~~~~~~~~~
     | A parameter cannot be found that matches parameter name 'OutputFormat'.

##[error]PowerShell exited with code '1'.
Finishing: Run PESTER tests
```

Tested in hmcts/grafana-infrastructure/pull/105

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
