### PR TITLE
feat: prioritize mainline/manual ADO runs in build gate, add max waittimeout, and add Python unit tests/docs for concurrency policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,27 @@
 .idea
 .DS_Store
+
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Tool and test caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Coverage outputs
+.coverage
+.coverage.*
+htmlcov/
+
+# Distribution and build artifacts
+build/
+dist/
+*.egg-info/

--- a/scripts/ado-build-check.py
+++ b/scripts/ado-build-check.py
@@ -254,12 +254,12 @@ def main(argv: list[str] | None = None) -> int:
     while True:
         elapsed = int(time.monotonic() - wait_start)
         if elapsed > max_wait_seconds:
-            logger.error(
-                "Timed out waiting for concurrency gate after %s seconds (max %s).",
+            logger.warning(
+                "Timed out waiting for concurrency gate after %s seconds (max %s). Proceeding without further blocking.",
                 elapsed,
                 max_wait_seconds,
             )
-            return 1
+            return 0
 
         builds_in_progress = get_builds(buildid, ado_definition_url)
         if isinstance(builds_in_progress, list) and builds_in_progress:

--- a/scripts/ado-build-check.py
+++ b/scripts/ado-build-check.py
@@ -1,187 +1,280 @@
+import argparse
+import json
+import logging
 import re
 import sys
-import json
 import time
-import argparse
-import logging
+from typing import Any
+
 import requests
-from requests.auth import HTTPBasicAuth
 
-retry_time_in_seconds = 10
+RETRY_TIME_IN_SECONDS = 10
+DEFAULT_MAX_WAIT_SECONDS = 800
 
-parser = argparse.ArgumentParser(description="Prevent parallel ADO Pipeline run")
+logger = logging.getLogger(__name__)
 
-parser.add_argument("--pat", type=str, help="Specify the ADO PAT token")
-parser.add_argument(
-    "--organization",
-    type=str,
-    help="Specify ADO Organisation",
-    required=True,
-)
-parser.add_argument(
-    "--project",
-    type=str,
-    help="Specify ADO Project",
-    required=True,
-)
-parser.add_argument(
-    "--pipelineid",
-    type=str,
-    help="Specify ADO pipeline id",
-    required=True,
-)
-parser.add_argument(
-    "--buildid", type=int, help="Current ADO run build id", required=True
-)
-parser.add_argument(
-    "-d",
-    "--debug",
-    help="Show debug logs",
-    action="store_const",
-    dest="loglevel",
-    const=logging.DEBUG,
-    default=logging.INFO,
-)
-args = parser.parse_args()
-
-logging.basicConfig(
-    level=args.loglevel,
-    format="[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s: %(message)s",
-    handlers=[
-        logging.StreamHandler(stream=sys.stdout),
-    ],
-)
-logger = logging.getLogger()
-
-organization = args.organization
-project = args.project
-pat = args.pat
-buildid = args.buildid
-pipelineid = args.pipelineid
-
-ado_definition_url = (
-    "https://dev.azure.com/"
-    + f"{organization}/"
-    + f"{project}"
-    + "/_apis/build/builds?api-version=5.1&definitions="
-    + f"{pipelineid}"
-)
+# Runtime settings are assigned in main().
+organization = ""
+project = ""
+pat = ""
+buildid = 0
+pipelineid = ""
+include_release_branches = False
+max_wait_seconds = DEFAULT_MAX_WAIT_SECONDS
 
 
-def get_builds(buildid, ado_definition_url):
-    """
-    This function takes a build ID and an ADO Definition URL and returns a list of builds
-    with information about their ID, build number, status, queue time, URL, and requested by.
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prevent parallel ADO pipeline run")
+    parser.add_argument("--pat", type=str, help="Specify the ADO PAT token")
+    parser.add_argument(
+        "--organization",
+        type=str,
+        help="Specify ADO organization",
+        required=True,
+    )
+    parser.add_argument(
+        "--project",
+        type=str,
+        help="Specify ADO project",
+        required=True,
+    )
+    parser.add_argument(
+        "--pipelineid",
+        type=str,
+        help="Specify ADO pipeline id",
+        required=True,
+    )
+    parser.add_argument("--buildid", type=int, help="Current ADO run build id", required=True)
+    parser.add_argument(
+        "--include-release-branches",
+        help="Treat refs/heads/release/* as mainline priority branches",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--max-wait-seconds",
+        type=int,
+        default=DEFAULT_MAX_WAIT_SECONDS,
+        help="Maximum seconds to wait before failing the concurrency gate",
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        help="Show debug logs",
+        action="store_const",
+        dest="loglevel",
+        const=logging.DEBUG,
+        default=logging.INFO,
+    )
+    return parser.parse_args(argv)
 
-    Parameters:
-    buildid (int): The ID of the build for which to return other builds.
-    ado_definition_url (str): The URL of the ADO definition.
 
-    Returns:
-    list: A list of builds with information about their ID, build number,
-    status, queue time, URL, and requested by.
+def configure_logging(loglevel: int) -> None:
+    logging.basicConfig(
+        level=loglevel,
+        format="[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s: %(message)s",
+        handlers=[logging.StreamHandler(stream=sys.stdout)],
+    )
 
-    Raises:
-    Exception: If an exception is raised, the debug info of the builds is logged.
 
-    This function will make a GET request to the provided ADO Definition URL, using an
-    authentication token (PAT) if provided. If the request is successful, it will parse
-    the returned JSON data to find builds with in progress status, and return a list
-    containing information about each of those builds. If the build ID provided is not
-    found in the returned builds, the function will log an error. If the request is not
-    successful, the function will log an error containing the relevant debug info.
-    In case of any exceptions, the function will raise an exception with the relevant
-    debug info.
-    """
-    
+def get_ado_definition_url(org: str, team_project: str, definition_id: str) -> str:
+    return (
+        "https://dev.azure.com/"
+        + f"{org}/"
+        + f"{team_project}"
+        + "/_apis/build/builds?api-version=7.1&definitions="
+        + f"{definition_id}"
+    )
+
+
+def get_request_headers() -> dict[str, str]:
+    return {"Authorization": "Bearer " + pat, "Content-Type": "application/json"}
+
+
+def is_mainline_branch(source_branch: str) -> bool:
+    if source_branch in {"refs/heads/main", "refs/heads/master"}:
+        return True
+    if include_release_branches and source_branch.startswith("refs/heads/release/"):
+        return True
+    return False
+
+
+def is_pr_build(build: dict[str, Any]) -> bool:
+    reason = (build.get("reason") or "").lower()
+    source_branch = build.get("sourceBranch") or ""
+    return reason == "pullrequest" or source_branch.startswith("refs/pull/")
+
+
+def is_manual_build(build: dict[str, Any]) -> bool:
+    reason = (build.get("reason") or "").lower()
+    return reason == "manual"
+
+
+def classify_build(build: dict[str, Any]) -> str:
+    source_branch = build.get("sourceBranch") or ""
+    if is_mainline_branch(source_branch):
+        return "mainline"
+    if is_manual_build(build):
+        return "manual"
+    if is_pr_build(build):
+        return "pr"
+    return "other"
+
+
+def class_priority(build_class: str) -> int:
+    priorities = {
+        "mainline": 0,
+        "manual": 1,
+        "pr": 2,
+        "other": 3,
+    }
+    return priorities.get(build_class, 3)
+
+
+def build_summary(build: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": build.get("id"),
+        "buildNumber": build.get("buildNumber"),
+        "status": build.get("status"),
+        "queueTime": build.get("queueTime"),
+        "startTime": build.get("startTime"),
+        "sourceBranch": build.get("sourceBranch"),
+        "reason": build.get("reason"),
+        "url": build.get("url"),
+        "requestedBy": build.get("requestedBy"),
+        "class": classify_build(build),
+    }
+
+
+def select_competing_builds(
+    current_build: dict[str, Any],
+    in_progress_builds: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return builds that are allowed to block current build under priority policy."""
+    current_class = classify_build(current_build)
+    current_priority = class_priority(current_class)
+    competitors = [current_build]
+
+    for other_build in in_progress_builds:
+        other_class = classify_build(other_build)
+        other_priority = class_priority(other_class)
+
+        # Higher-priority or same-priority classes can block; lower-priority classes cannot.
+        if other_priority <= current_priority:
+            competitors.append(other_build)
+
+    return competitors
+
+
+def get_builds(current_build_id: int, ado_definition_url: str) -> list[dict[str, Any]] | None:
+    """Return competing in-progress builds for current build, or None if current build may proceed."""
     try:
-        builds = requests.get(ado_definition_url, headers={'Authorization': 'Bearer ' + pat, 'Content-Type': 'application/json'})
-        if builds:
-            builds = builds.json()
-            logger.info(f"Provided builds.json is : {builds}")
-            if "value" in builds:
-                builds = builds["value"]
-                build_ids = [build["id"] for build in builds]
-                if buildid not in build_ids:
-                    logger.error(f"Provided build id {buildid} not found in builds.")
-                    return False
-
-                build_ids_in_progress = [
-                    build["id"] for build in builds if "inProgress" in build["status"]
-                ]
-                if min(build_ids_in_progress) == buildid:
-                    logger.info(f"Build id {buildid} is next in queue. Exiting...")
-                    return
-
-                return [
-                    {
-                        "id": build["id"],
-                        "buildNumber": build["buildNumber"],
-                        "status": build["status"],
-                        "queueTime": build["queueTime"],
-                        "url": build["url"],
-                        "requestedBy": build["requestedBy"],
-                    }
-                    for build in builds
-                    if "inProgress" in build["status"] and build["id"] != buildid
-                ]
-        if builds.status_code == 401 and len(builds.text) == 0:
-            logger.error("401 response - PAT token provided is invalid")
+        response = requests.get(
+            ado_definition_url,
+            headers=get_request_headers(),
+            timeout=30,
+        )
+        if response.status_code == 401 and len(response.text) == 0:
+            logger.error("401 response - token provided is invalid")
             raise SystemExit(1)
-        if not builds:
-            try:
-                if "<title>" in builds.text:
-                    # Try to parse title HTML tag if HTML error type.
-                    title = re.findall("<title>(.*?)</title>", builds.text)
-                    if title:
-                        logger.error(title)
-                        raise SystemExit(1)
-                    else:
-                        logger.error(builds.text)
-                        raise SystemExit(1)
-                else:
-                    logger.error(builds.content)
-                    raise SystemExit(1)
-            except Exception as e:
-                logger.info("Unknown error...\n\n")
-                raise Exception(e)
 
-    except Exception as e:
-        raise Exception(e)
+        response.raise_for_status()
+    except requests.RequestException as error:
+        logger.error("ADO builds query failed: %s", error)
+        raise
+
+    try:
+        payload = response.json()
+    except ValueError as error:
+        logger.error("ADO builds query returned invalid JSON")
+        raise RuntimeError("Invalid JSON payload from ADO builds API") from error
+
+    logger.debug("Provided builds.json is : %s", payload)
+    builds = payload.get("value", [])
+    if not builds:
+        raise RuntimeError("No build data returned for pipeline definition")
+
+    build_ids = [build.get("id") for build in builds]
+    if current_build_id not in build_ids:
+        raise RuntimeError(f"Provided build id {current_build_id} not found in builds")
+
+    in_progress_builds = [
+        build for build in builds if "inProgress" in (build.get("status") or "")
+    ]
+    current_build = next(
+        (build for build in in_progress_builds if build.get("id") == current_build_id),
+        None,
+    )
+    if not current_build:
+        logger.info("Current build %s is not in progress anymore. Exiting...", current_build_id)
+        return None
+
+    other_in_progress = [
+        build for build in in_progress_builds if build.get("id") != current_build_id
+    ]
+
+    competitors = select_competing_builds(current_build, other_in_progress)
+    if min(build["id"] for build in competitors) == current_build_id:
+        logger.info(
+            "Build id %s can proceed under policy (class=%s).",
+            current_build_id,
+            classify_build(current_build),
+        )
+        return None
+
+    return [
+        build_summary(build)
+        for build in competitors
+        if build.get("id") != current_build_id
+    ]
 
 
-def main():
-    """
-    The main() function is responsible for looping through the list of builds that are in progress and displaying their information.
-    If there are no builds in progress, it will exit the loop and terminate. If there are builds in progress, it will log the information
-    of each build and wait a specified time before checking again.
+def main(argv: list[str] | None = None) -> int:
+    global organization
+    global project
+    global pat
+    global buildid
+    global pipelineid
+    global include_release_branches
+    global max_wait_seconds
 
-    Args:
-      builds_in_progress (list): A list of builds that are currently in progress.
-      retry_time_in_seconds (int): The time in seconds to wait before checking again.
-      buildid (int): The ID of the build.
-      ado_definition_url (str): The URL of the Azure DevOps definition.
+    args = parse_args(argv)
+    configure_logging(args.loglevel)
 
-    Returns:
-      None
-    """
+    organization = args.organization
+    project = args.project
+    pat = args.pat
+    buildid = args.buildid
+    pipelineid = args.pipelineid
+    include_release_branches = args.include_release_branches
+    max_wait_seconds = max(1, args.max_wait_seconds)
+
+    ado_definition_url = get_ado_definition_url(organization, project, pipelineid)
+    wait_start = time.monotonic()
 
     while True:
+        elapsed = int(time.monotonic() - wait_start)
+        if elapsed > max_wait_seconds:
+            logger.error(
+                "Timed out waiting for concurrency gate after %s seconds (max %s).",
+                elapsed,
+                max_wait_seconds,
+            )
+            return 1
+
         builds_in_progress = get_builds(buildid, ado_definition_url)
-        if isinstance(builds_in_progress, list):
-            if len(builds_in_progress) > 0:
-                logger.info(
-                    f"There is currently {len(builds_in_progress)} builds in progress..."
-                )
-                logger.info(json.dumps(builds_in_progress, indent=4))
-                logger.info(f"Re-trying in {retry_time_in_seconds} seconds...")
-                time.sleep(retry_time_in_seconds)
-            else:
-                logger.info("There are no other builds in progress...")
-                break
-        else:
-            break
+        if isinstance(builds_in_progress, list) and builds_in_progress:
+            logger.info(
+                "There are currently %s competing builds in progress...",
+                len(builds_in_progress),
+            )
+            logger.info(json.dumps(builds_in_progress, indent=4))
+            logger.info("Re-trying in %s seconds...", RETRY_TIME_IN_SECONDS)
+            time.sleep(RETRY_TIME_IN_SECONDS)
+            continue
+
+        logger.info("There are no competing builds in progress...")
+        return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/ado-build-check.py
+++ b/scripts/ado-build-check.py
@@ -165,6 +165,18 @@ def select_competing_builds(
     return competitors
 
 
+def competitor_log_details(builds: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": build.get("id"),
+            "class": classify_build(build),
+            "reason": build.get("reason"),
+            "sourceBranch": build.get("sourceBranch"),
+        }
+        for build in builds
+    ]
+
+
 def get_builds(current_build_id: int, ado_definition_url: str) -> list[dict[str, Any]] | None:
     """Return competing in-progress builds for current build, or None if current build may proceed."""
     try:
@@ -213,6 +225,14 @@ def get_builds(current_build_id: int, ado_definition_url: str) -> list[dict[str,
     ]
 
     competitors = select_competing_builds(current_build, other_in_progress)
+    logger.info(
+        "Build id %s classified as %s. Total in-progress seen=%s. Policy competitors=%s",
+        current_build_id,
+        classify_build(current_build),
+        len(in_progress_builds),
+        competitor_log_details([build for build in competitors if build.get("id") != current_build_id]),
+    )
+
     if min(build["id"] for build in competitors) == current_build_id:
         logger.info(
             "Build id %s can proceed under policy (class=%s).",

--- a/steps/terraform-precheck.yaml
+++ b/steps/terraform-precheck.yaml
@@ -146,21 +146,7 @@ steps:
         
   - task: Bash@3
     displayName: Prevent parallel run
-    # Run step if (not a plan and is manually triggered) or (branch is main and is auto triggered)
-    condition: |
-      and(succeeded(),
-        or(
-            eq(${{ parameters.forcePreventParallelJobRun }}, true),
-            and(
-                ne('${{ parameters.overrideAction }}', 'plan'),
-                eq(variables['isAutoTriggered'], false)
-            ),
-            and(
-                eq(variables['isAutoTriggered'], true),
-                eq(variables['isMain'], true)
-            )
-        )
-      )
+    condition: succeeded()
     env:
       thisbuild: $(Build.BuildId)
       pipelinedefinition: $(System.DefinitionId)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,32 @@
+# Tests
+
+This folder contains test files for scripts under `scripts/`.
+
+## Python
+
+### Run All Tests
+
+From repository root:
+
+```bash
+python3 -m py_compile scripts/*.py tests/test_*.py
+python3 -m unittest discover -s tests -p "test_*.py"
+```
+
+### Run One Test File
+
+```bash
+python3 -m unittest tests/test_<name>.py
+```
+
+
+### Run With Verbose Output
+```bash
+python3 -m unittest -v tests/test_<name>.py
+```
+
+### Notes
+
+- Tests use Python standard library `unittest`.
+- Keep test files named `test_*.py` so discovery works.
+- If a test needs third-party packages, document and install them in project dependency files.

--- a/tests/test_ado_build_check.py
+++ b/tests/test_ado_build_check.py
@@ -1,0 +1,99 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+SCRIPT_PATH = pathlib.Path(__file__).resolve().parents[1] / "scripts" / "ado-build-check.py"
+SPEC = importlib.util.spec_from_file_location("ado_build_check", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+
+# Provide lightweight stub so policy tests run even when requests is not installed.
+requests_stub = types.ModuleType("requests")
+requests_stub.RequestException = Exception
+def _unused_get(*_args, **_kwargs):
+    raise NotImplementedError("requests.get not used in policy tests")
+requests_stub.get = _unused_get
+sys.modules.setdefault("requests", requests_stub)
+
+SPEC.loader.exec_module(MODULE)
+
+
+class AdoBuildCheckTests(unittest.TestCase):
+    def setUp(self) -> None:
+        MODULE.include_release_branches = False
+
+    @staticmethod
+    def build(build_id: int, source_branch: str, reason: str, status: str = "inProgress"):
+        return {
+            "id": build_id,
+            "sourceBranch": source_branch,
+            "reason": reason,
+            "status": status,
+        }
+
+    def test_classify_mainline_beats_reason(self):
+        build = self.build(1, "refs/heads/main", "manual")
+        self.assertEqual(MODULE.classify_build(build), "mainline")
+
+    def test_classify_manual(self):
+        build = self.build(2, "refs/heads/feature/x", "manual")
+        self.assertEqual(MODULE.classify_build(build), "manual")
+
+    def test_classify_pr(self):
+        build = self.build(3, "refs/pull/12/merge", "pullRequest")
+        self.assertEqual(MODULE.classify_build(build), "pr")
+
+    def test_classify_other(self):
+        build = self.build(4, "refs/heads/feature/x", "individualCI")
+        self.assertEqual(MODULE.classify_build(build), "other")
+
+    def test_mainline_ignores_lower_priorities(self):
+        current = self.build(10, "refs/heads/main", "individualCI")
+        others = [
+            self.build(11, "refs/heads/feature/a", "manual"),
+            self.build(12, "refs/pull/1/merge", "pullRequest"),
+            self.build(13, "refs/heads/feature/b", "individualCI"),
+        ]
+
+        competitors = MODULE.select_competing_builds(current, others)
+        self.assertEqual([build["id"] for build in competitors], [10])
+
+    def test_manual_waits_for_mainline_not_pr_or_other(self):
+        current = self.build(20, "refs/heads/feature/a", "manual")
+        others = [
+            self.build(21, "refs/heads/main", "individualCI"),
+            self.build(22, "refs/pull/1/merge", "pullRequest"),
+            self.build(23, "refs/heads/feature/b", "individualCI"),
+        ]
+
+        competitors = MODULE.select_competing_builds(current, others)
+        self.assertEqual([build["id"] for build in competitors], [20, 21])
+
+    def test_pr_waits_for_mainline_and_manual(self):
+        current = self.build(30, "refs/pull/2/merge", "pullRequest")
+        others = [
+            self.build(31, "refs/heads/main", "individualCI"),
+            self.build(32, "refs/heads/feature/a", "manual"),
+            self.build(33, "refs/heads/feature/b", "individualCI"),
+        ]
+
+        competitors = MODULE.select_competing_builds(current, others)
+        self.assertEqual([build["id"] for build in competitors], [30, 31, 32])
+
+    def test_other_waits_for_everything(self):
+        current = self.build(40, "refs/heads/feature/z", "individualCI")
+        others = [
+            self.build(41, "refs/heads/main", "individualCI"),
+            self.build(42, "refs/heads/feature/a", "manual"),
+            self.build(43, "refs/pull/3/merge", "pullRequest"),
+        ]
+
+        competitors = MODULE.select_competing_builds(current, others)
+        self.assertEqual([build["id"] for build in competitors], [40, 41, 42, 43])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-33298

### Change description
Update `ado-build-check.py` to improve/add:
Prioritize mainline/manual ADO runs in build gate
Add max wait timeout
Add Python unit tests for `ado-build-check.py` and readme for test files for concurrency policy

Python best practice agent skill used as well to review and  update `ado-build-check.py`

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
