### PR TITLE
ado-build-check: fail open when current build missing from ADO builds…

### DIFF
--- a/scripts/ado-build-check.py
+++ b/scripts/ado-build-check.py
@@ -203,11 +203,19 @@ def get_builds(current_build_id: int, ado_definition_url: str) -> list[dict[str,
     logger.debug("Provided builds.json is : %s", payload)
     builds = payload.get("value", [])
     if not builds:
-        raise RuntimeError("No build data returned for pipeline definition")
+        # Fail open: an empty/unexpected response should not block the pipeline.
+        logger.warning("No build data returned for pipeline definition. Proceeding without blocking.")
+        return None
 
     build_ids = [build.get("id") for build in builds]
     if current_build_id not in build_ids:
-        raise RuntimeError(f"Provided build id {current_build_id} not found in builds")
+        # Fail open: the ADO builds API can omit the current build (e.g. paging/eventual
+        # consistency), so treat this as "cannot determine competitors" rather than fatal.
+        logger.warning(
+            "Provided build id %s not found in builds returned by the API. Proceeding without blocking.",
+            current_build_id,
+        )
+        return None
 
     in_progress_builds = [
         build for build in builds if "inProgress" in (build.get("status") or "")

--- a/tests/test_ado_build_check.py
+++ b/tests/test_ado_build_check.py
@@ -94,6 +94,24 @@ class AdoBuildCheckTests(unittest.TestCase):
         competitors = MODULE.select_competing_builds(current, others)
         self.assertEqual([build["id"] for build in competitors], [40, 41, 42, 43])
 
+    @staticmethod
+    def _fake_response(payload, status_code=200, text="ok"):
+        response = types.SimpleNamespace()
+        response.status_code = status_code
+        response.text = text
+        response.json = lambda: payload
+        response.raise_for_status = lambda: None
+        return response
+
+    def test_get_builds_fails_open_when_no_builds_returned(self):
+        MODULE.requests.get = lambda *a, **k: self._fake_response({"value": []})
+        self.assertIsNone(MODULE.get_builds(999, "http://example.invalid"))
+
+    def test_get_builds_fails_open_when_current_build_missing(self):
+        other = self.build(1, "refs/heads/feature/x", "individualCI")
+        MODULE.requests.get = lambda *a, **k: self._fake_response({"value": [other]})
+        self.assertIsNone(MODULE.get_builds(999, "http://example.invalid"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
… API response

PR #277's rewrite turned a 'build id not found in builds' condition into a hard RuntimeError, failing every consuming pipeline's 'Prevent parallel run' step (e.g. hmcts/azure-access build 1176493, 2026-08-06) whenever the ADO builds API response doesn't include the current build. Restore fail-open behaviour (log + proceed) consistent with the existing max-wait-seconds timeout fail-open path, instead of hard-failing the concurrency gate.

### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
