### PR TITLE
fix: fail open concurrency gate on empty/missing ADO build list results with build-by-id fallback

### DIFF
--- a/scripts/ado-build-check.py
+++ b/scripts/ado-build-check.py
@@ -245,7 +245,10 @@ def get_builds(current_build_id: int, ado_definition_url: str) -> list[dict[str,
     logger.debug("Provided builds.json is : %s", payload)
     builds = payload.get("value", [])
     if not builds:
-        raise RuntimeError("No build data returned for pipeline definition")
+        logger.warning(
+            "No build data returned for pipeline definition. Proceeding without blocking."
+        )
+        return None
 
     build_ids = [build.get("id") for build in builds]
     build_missing_from_list = current_build_id not in build_ids

--- a/scripts/ado-build-check.py
+++ b/scripts/ado-build-check.py
@@ -86,8 +86,50 @@ def get_ado_definition_url(org: str, team_project: str, definition_id: str) -> s
     )
 
 
+def get_ado_build_url(org: str, team_project: str, build_id: int) -> str:
+    return (
+        "https://dev.azure.com/"
+        + f"{org}/"
+        + f"{team_project}"
+        + "/_apis/build/builds/"
+        + f"{build_id}?api-version=7.1"
+    )
+
+
 def get_request_headers() -> dict[str, str]:
     return {"Authorization": "Bearer " + pat, "Content-Type": "application/json"}
+
+
+def get_build_by_id(build_id: int) -> dict[str, Any] | None:
+    """Fetch a single build; return None when build no longer exists or is inaccessible."""
+    build_url = get_ado_build_url(organization, project, build_id)
+    try:
+        response = requests.get(
+            build_url,
+            headers=get_request_headers(),
+            timeout=30,
+        )
+        if response.status_code == 404:
+            logger.warning("Current build id %s not found via build-by-id API", build_id)
+            return None
+        if response.status_code == 401 and len(response.text) == 0:
+            logger.error("401 response - token provided is invalid")
+            raise SystemExit(1)
+
+        response.raise_for_status()
+    except requests.RequestException as error:
+        logger.error("ADO build-by-id query failed: %s", error)
+        raise
+
+    try:
+        payload = response.json()
+    except ValueError as error:
+        logger.error("ADO build-by-id query returned invalid JSON")
+        raise RuntimeError("Invalid JSON payload from ADO build-by-id API") from error
+
+    if not isinstance(payload, dict) or payload.get("id") != build_id:
+        logger.warning("Unexpected build-by-id payload for build id %s", build_id)
+    return payload if isinstance(payload, dict) else None
 
 
 def is_mainline_branch(source_branch: str) -> bool:
@@ -206,8 +248,7 @@ def get_builds(current_build_id: int, ado_definition_url: str) -> list[dict[str,
         raise RuntimeError("No build data returned for pipeline definition")
 
     build_ids = [build.get("id") for build in builds]
-    if current_build_id not in build_ids:
-        raise RuntimeError(f"Provided build id {current_build_id} not found in builds")
+    build_missing_from_list = current_build_id not in build_ids
 
     in_progress_builds = [
         build for build in builds if "inProgress" in (build.get("status") or "")
@@ -216,6 +257,30 @@ def get_builds(current_build_id: int, ado_definition_url: str) -> list[dict[str,
         (build for build in in_progress_builds if build.get("id") == current_build_id),
         None,
     )
+
+    if not current_build and build_missing_from_list:
+        logger.warning(
+            "Current build id %s missing from builds list API response; using build-by-id fallback",
+            current_build_id,
+        )
+        current_build = get_build_by_id(current_build_id)
+
+        if not current_build:
+            logger.info("Current build %s is unavailable. Exiting...", current_build_id)
+            return None
+
+        current_status = (current_build.get("status") or "").lower()
+        if "inprogress" not in current_status:
+            logger.info(
+                "Current build %s status is %s. Exiting...",
+                current_build_id,
+                current_build.get("status"),
+            )
+            return None
+
+        if current_build_id not in [build.get("id") for build in in_progress_builds]:
+            in_progress_builds.append(current_build)
+
     if not current_build:
         logger.info("Current build %s is not in progress anymore. Exiting...", current_build_id)
         return None

--- a/tests/test_ado_build_check.py
+++ b/tests/test_ado_build_check.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 import types
 import unittest
+from unittest import mock
 
 
 SCRIPT_PATH = pathlib.Path(__file__).resolve().parents[1] / "scripts" / "ado-build-check.py"
@@ -93,6 +94,106 @@ class AdoBuildCheckTests(unittest.TestCase):
 
         competitors = MODULE.select_competing_builds(current, others)
         self.assertEqual([build["id"] for build in competitors], [40, 41, 42, 43])
+
+    class _FakeResponse:
+        def __init__(self, status_code: int, payload: dict | None = None, text: str = ""):
+            self.status_code = status_code
+            self._payload = payload
+            self.text = text
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise MODULE.requests.RequestException(f"HTTP {self.status_code}")
+
+        def json(self):
+            return self._payload
+
+    def test_get_builds_empty_payload_fails_open(self):
+        MODULE.pat = "token"
+        with mock.patch.object(
+            MODULE.requests,
+            "get",
+            return_value=self._FakeResponse(200, {"value": []}),
+        ):
+            result = MODULE.get_builds(123, "https://dev.azure.com/org/proj/_apis/build/builds")
+        self.assertIsNone(result)
+
+    def test_get_builds_missing_current_id_fallback_not_in_progress_returns_none(self):
+        MODULE.pat = "token"
+        MODULE.organization = "org"
+        MODULE.project = "proj"
+
+        list_payload = {
+            "value": [
+                {
+                    "id": 50,
+                    "sourceBranch": "refs/pull/50/merge",
+                    "reason": "pullRequest",
+                    "status": "inProgress",
+                }
+            ]
+        }
+        fallback_payload = {
+            "id": 123,
+            "sourceBranch": "refs/pull/123/merge",
+            "reason": "pullRequest",
+            "status": "completed",
+        }
+
+        with mock.patch.object(
+            MODULE.requests,
+            "get",
+            side_effect=[
+                self._FakeResponse(200, list_payload),
+                self._FakeResponse(200, fallback_payload),
+            ],
+        ):
+            result = MODULE.get_builds(123, "https://dev.azure.com/org/proj/_apis/build/builds")
+
+        self.assertIsNone(result)
+
+    def test_get_builds_missing_current_id_fallback_in_progress_keeps_policy(self):
+        MODULE.pat = "token"
+        MODULE.organization = "org"
+        MODULE.project = "proj"
+
+        other_pr_in_progress = {
+            "id": 20,
+            "sourceBranch": "refs/pull/20/merge",
+            "reason": "pullRequest",
+            "status": "inProgress",
+            "buildNumber": "20",
+            "queueTime": "2026-08-06T00:00:00Z",
+            "startTime": "2026-08-06T00:00:10Z",
+            "url": "https://example/20",
+            "requestedBy": {"displayName": "User A"},
+        }
+        list_payload = {"value": [other_pr_in_progress]}
+        fallback_payload = {
+            "id": 30,
+            "sourceBranch": "refs/pull/30/merge",
+            "reason": "pullRequest",
+            "status": "inProgress",
+            "buildNumber": "30",
+            "queueTime": "2026-08-06T00:01:00Z",
+            "startTime": "2026-08-06T00:01:10Z",
+            "url": "https://example/30",
+            "requestedBy": {"displayName": "User B"},
+        }
+
+        with mock.patch.object(
+            MODULE.requests,
+            "get",
+            side_effect=[
+                self._FakeResponse(200, list_payload),
+                self._FakeResponse(200, fallback_payload),
+            ],
+        ):
+            result = MODULE.get_builds(30, "https://dev.azure.com/org/proj/_apis/build/builds")
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], 20)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description
This PR hardens ADO concurrency check against transient API inconsistencies.

- Adds build-by-id fallback when current build ID is missing from definition build list.
- Changes empty build-list response handling to fail open with warning, not hard failure.
- Keeps existing blocking behavior when valid competitor builds are found.
- Prevents false-negative pipeline failures caused by paging, lag, or eventual consistency in ADO build list API.
- Validated with local syntax compile for ado-build-check.py